### PR TITLE
fix(emotion): prevent gender_negative token accumulation across emotions

### DIFF
--- a/nodes/emotion_generator.py
+++ b/nodes/emotion_generator.py
@@ -114,12 +114,14 @@ class EmotionGenerator:
             lora_prompt = info.get("lora_prompt", "")
             negative_prompt = info.get("negative_prompt", "")
             negative_prompt = negative_prompt + "(facial droplet), (water drop), (water), (water droplets), (water drops)"
+            base_negative_prompt = negative_prompt
             config_seed = info.get("seed", 0)
             seed = generate_seed(config_seed)
         else:
             print(f"[EmotionGenerator] Character '{character}' not found")
             info = {}
             aesthetics = background_color = sex = race = eyes = hair = face_features = body = skin_color = additional_details = negative_prompt = lora_prompt = ""
+            base_negative_prompt = ""
             age = 18
             seed = generate_seed(0)
 
@@ -168,7 +170,7 @@ class EmotionGenerator:
                 if additional_details:
                     positive_prompt += f", ({additional_details})"
                 positive_prompt, gender_negative = apply_sex(sex, positive_prompt, "")
-                negative_prompt += f", {gender_negative}"
+                negative_prompt = f"{base_negative_prompt}, {gender_negative}"
                 positive_prompt = append_age(positive_prompt, age, sex)
                 if lora_prompt:
                     positive_prompt += f", {lora_prompt}"


### PR DESCRIPTION
## Summary

- **Bug #5** `negative_prompt += f", {gender_negative}"` ran inside the `for emotion_key in emotions_list` loop. `gender_negative` is constant per character (depends only on `sex`), but the `+=` accumulated it once per emotion. After N emotions, the negative prompt contained the gender tokens N times.

Fixed: `base_negative_prompt` snapshot taken after the per-character negative is built (before the emotion loop). Inside the loop, assignment replaces accumulation: `negative_prompt = f"{base_negative_prompt}, {gender_negative}"`. Same pattern already used in `emotion_generator_v2.py` line 320.

## Test plan

- [ ] Generate a character with 3+ emotions — confirm `negative_prompt` in log output has gender tokens exactly once
- [ ] Check console: `negative_prompt:` line should not contain duplicated tokens