### PR TITLE
3.0.1

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,47 @@
+# VNCCS 3.0.1 Changelog
+
+This changelog describes the user-visible changes in version `3.0.1` compared with `3.0.0`.
+It focuses on workflow behavior and UI changes, not internal refactors.
+
+## Headline Changes
+
+- SeedVR upscaling now exposes a color-correction selector in the generator UI.
+- Emotion Studio and Character Creator V2 now use the same seed behavior as Clothes Designer: `seed = 0` can stay fixed, and randomization happens on queue only when random mode is enabled.
+- Illustrious turbo mode now works consistently across Emotion Studio, Character Creator V2, and Control Center: enabling turbo sets `steps = 4` and `cfg = 1`, disabling it restores the previous values.
+- Emotion Studio no longer uses a separate prompt-style selector in the widget header; prompt style is now derived automatically from the selected generation model.
+- Control Center now shows Turbo LoRA as an inline selector in the `MODEL` section instead of a separate `Turbo Model` card.
+
+## Character Generator
+
+- Added a SeedVR color-correction selector with multiple modes such as `lab`, `adain`, `wavelet`, and `none`.
+- Added help text so users can more easily switch away from `lab` when a GPU produces unwanted color shifts.
+
+## Emotion Studio
+
+- Removed the old top-left prompt-style selector from the widget.
+- Prompt style is now chosen automatically from the selected generation mode: `Anima` mode uses the Anima prompt path, while `Illustrious` mode uses the SDXL-style prompt path.
+- The seed field is now shared between Anima and Illustrious profiles so both modes show and use the same seed.
+- Random seed mode now generates a new seed only when the workflow is queued, instead of rewriting the seed immediately in the UI.
+- The Illustrious turbo toggle now stores the previous `steps/cfg`, switches to `4 / 1` while enabled, and restores the saved values when disabled.
+- The LoRA section now stays available for both generation modes and updates its header and card set to match the active mode.
+
+## Character Creator V2
+
+- Seed handling now matches Clothes Designer semantics more closely.
+- Default generation seed values are now initialized to `0` in fixed mode instead of being auto-randomized.
+- Backend seed resolution now respects `seed_mode`, which keeps preview generation, pipe generation, and sampler execution consistent.
+- The Illustrious turbo toggle now behaves like the other updated widgets: it saves previous `steps/cfg`, applies `4 / 1` while active, and restores the earlier values when turned off.
+
+## Control Center
+
+- `CUSTOM` pass-through mode now expects external `MODEL`, `CLIP`, and `VAE` inputs together, instead of showing the normal internal CLIP/VAE asset cards.
+- Turbo LoRA has been moved into the `MODEL` block as a flat inline selector under the model and parameter area.
+- The old standalone `Turbo Model` section has been removed.
+- Turbo is no longer force-enabled just because `steps/cfg` happen to be `4 / 1`.
+- Toggling Turbo LoRA on now saves the current `steps/cfg` and applies `4 / 1`; toggling it off restores the saved values.
+- Hovering the Turbo LoRA selector no longer makes the toggle visually jump.
+- Dependency/setup status can now show warning states more clearly instead of treating every non-OK condition as a hard failure.
+
 # VNCCS 3.0.0 Changelog
 
 This changelog describes the user-visible changes in the current branch compared with `main`.

--- a/nodes/character_creator_v2.py
+++ b/nodes/character_creator_v2.py
@@ -139,6 +139,13 @@ ANIMA_DEFAULTS = {
     "lora_stack": [],
 }
 
+
+def resolve_generation_seed(gen_settings):
+    seed = int(gen_settings.get("seed", 0) or 0)
+    if str(gen_settings.get("seed_mode", "fixed") or "fixed").lower() == "randomize":
+        return generate_seed(0)
+    return seed
+
 DEFAULT_PREVIEW_WIDTH = 640
 DEFAULT_PREVIEW_HEIGHT = 1536
 
@@ -997,7 +1004,7 @@ Example:
             cfg = float(gen_settings.get("cfg", 8.0))
             sampler_name = gen_settings.get("sampler", "euler")
             scheduler = gen_settings.get("scheduler", "normal")
-            seed = generate_seed(int(gen_settings.get("seed", 0)))
+            seed = resolve_generation_seed(gen_settings)
             generation_mode = gen_settings.get("generation_mode", "illustrious")
 
             # Resolution
@@ -1310,7 +1317,7 @@ class CharacterCreatorV2:
             vae=vae,
             pos=conditioning_pos,
             neg=conditioning_neg,
-            seed_int=generate_seed(int(gen_settings.get("seed", 0))),
+            seed_int=resolve_generation_seed(gen_settings),
             sample_steps=int(gen_settings.get("steps", ILLUSTRIOUS_DEFAULTS["steps"])),
             cfg=float(gen_settings.get("cfg", ILLUSTRIOUS_DEFAULTS["cfg"])),
             denoise=1.0,
@@ -1404,7 +1411,7 @@ class CharacterCreatorV2:
             try:
                 sampled = sample_generation_latent(
                     model=model,
-                    seed=generate_seed(int(gen_settings.get("seed", 0))),
+                    seed=resolve_generation_seed(gen_settings),
                     steps=int(gen_settings.get("steps", ILLUSTRIOUS_DEFAULTS["steps"])),
                     cfg=float(gen_settings.get("cfg", ILLUSTRIOUS_DEFAULTS["cfg"])),
                     sampler_name=gen_settings.get("sampler", ILLUSTRIOUS_DEFAULTS["sampler"]),

--- a/nodes/emotion_generator_v2.py
+++ b/nodes/emotion_generator_v2.py
@@ -471,6 +471,8 @@ class EmotionGeneratorV2:
 
     def generate_emotions_v2(self, generation_model="Anima", generation_settings="{}", prompt_style="Anima", character="Character Name", costumes_data="[]", emotions_data="[]"):
         pipe, pipe_seed = build_emotion_pipe(generation_model, generation_settings)
+        mode = str(generation_model or "Anima").lower()
+        effective_prompt_style = "Anima" if mode == "anima" else "SDXL Style"
         
         try:
             selected_costumes = json.loads(costumes_data)
@@ -570,7 +572,7 @@ class EmotionGeneratorV2:
                 if costume_details:
                     face_details = f"{face_details}, {costume_details}" if face_details else costume_details
                 
-                if prompt_style in ("Anima", "QWEN Style"):
+                if effective_prompt_style == "Anima":
                     if face_details:
                         positive_prompt += f", Character face details: {face_details}"
                     emotion_text = build_anima_emotion_prompt(natural_prompt, emotion_description, emotion_key)

--- a/nodes/emotion_generator_v2.py
+++ b/nodes/emotion_generator_v2.py
@@ -111,6 +111,13 @@ def default_generation_settings():
     return settings
 
 
+def resolve_generation_seed(gen_settings):
+    seed = int(gen_settings.get("seed", 0) or 0)
+    if str(gen_settings.get("seed_mode", "fixed") or "fixed").lower() == "randomize":
+        return generate_seed(0)
+    return seed
+
+
 def build_emotion_pipe(generation_model="Anima", generation_settings="{}"):
     try:
         parsed = json.loads(generation_settings) if generation_settings else {}
@@ -165,7 +172,7 @@ def build_emotion_pipe(generation_model="Anima", generation_settings="{}"):
             if isinstance(item, dict):
                 model, clip = apply_lora_safe(model, clip, item.get("name"), item.get("strength", 1.0))
 
-    seed = generate_seed(int(gen_settings.get("seed", 0) or 0))
+    seed = resolve_generation_seed(gen_settings)
     pipe_node = VNCCS_Pipe()
     pipe_result = pipe_node.process_pipe(
         model=model,
@@ -515,12 +522,11 @@ class EmotionGeneratorV2:
             negative_prompt = info.get("negative_prompt", "") 
             negative_prompt = negative_prompt + ", (facial droplet), (water drop), (water), (water droplets), (water drops)"
             
-            config_seed = info.get("seed", 0)
-            seed = pipe_seed or generate_seed(config_seed)
+            seed = pipe_seed
             base_negative_prompt = negative_prompt
             positive_prompt = aesthetics
         else:
-             seed = pipe_seed or 0
+             seed = pipe_seed
              base_negative_prompt = ""
              positive_prompt = ""
              print(f"Character info not found for {character}")

--- a/nodes/vnccs_control_center.py
+++ b/nodes/vnccs_control_center.py
@@ -932,13 +932,25 @@ def _load_vae(vae_entries, selected_name):
     return comfy.sd.VAE(sd=sd, metadata=metadata)
 
 
-def _load_model_block(model_entry, selected_type, type_settings, config, selected_clips, selected_vae, custom_model=None):
+def _load_model_block(
+    model_entry,
+    selected_type,
+    type_settings,
+    config,
+    selected_clips,
+    selected_vae,
+    custom_model=None,
+    custom_clip=None,
+    custom_vae=None,
+):
     if selected_type == "custom":
         if custom_model is None:
             raise RuntimeError("[VNCCS Control Center] Custom model input is not connected.")
-        clip = _load_clips(config.get("clip", []), selected_clips)
-        vae = _load_vae(config.get("vae", []), selected_vae)
-        return custom_model, clip, vae
+        if custom_clip is None:
+            raise RuntimeError("[VNCCS Control Center] Custom CLIP input is not connected.")
+        if custom_vae is None:
+            raise RuntimeError("[VNCCS Control Center] Custom VAE input is not connected.")
+        return custom_model, custom_clip, custom_vae
 
     if not model_entry:
         raise RuntimeError("[VNCCS Control Center] No model selected.")
@@ -1170,6 +1182,8 @@ class VNCCS_ControlCenter:
             },
             "optional": {
                 "model": ("MODEL",),
+                "clip": ("CLIP",),
+                "vae": ("VAE",),
             }
         }
 
@@ -1182,12 +1196,18 @@ class VNCCS_ControlCenter:
     FUNCTION = "execute"
     CATEGORY = "VNCCS/manager"
 
-    def execute(self, repo_id, node_state="{}", model=None):
-        pipe = _build_control_center_pipe(repo_id, node_state, custom_model=model)
+    def execute(self, repo_id, node_state="{}", model=None, clip=None, vae=None):
+        pipe = _build_control_center_pipe(
+            repo_id,
+            node_state,
+            custom_model=model,
+            custom_clip=clip,
+            custom_vae=vae,
+        )
         return (pipe,)
 
 
-def _build_control_center_pipe(repo_id, node_state, custom_model=None):
+def _build_control_center_pipe(repo_id, node_state, custom_model=None, custom_clip=None, custom_vae=None):
     try:
         state = json.loads(node_state) if isinstance(node_state, str) and node_state and node_state != "{}" else (node_state or {})
     except Exception:
@@ -1230,10 +1250,14 @@ def _build_control_center_pipe(repo_id, node_state, custom_model=None):
         raise RuntimeError(f"[VNCCS Control Center] {NUNCHAKU_DISABLED_MESSAGE}")
 
     model_kind = _entry_kind(model_entry)
-    compatible_clips = _filter_entries_by_kind(config.get("clip", []), model_kind)
-    compatible_vaes = _filter_entries_by_kind(config.get("vae", []), model_kind)
-    all_clip_names = [entry["name"] for entry in compatible_clips]
-    first_vae_name = compatible_vaes[0]["name"] if compatible_vaes else ""
+    if selected_type == "custom":
+        all_clip_names = []
+        first_vae_name = ""
+    else:
+        compatible_clips = _filter_entries_by_kind(config.get("clip", []), model_kind)
+        compatible_vaes = _filter_entries_by_kind(config.get("vae", []), model_kind)
+        all_clip_names = [entry["name"] for entry in compatible_clips]
+        first_vae_name = compatible_vaes[0]["name"] if compatible_vaes else ""
     model, clip, vae = _load_model_block(
         model_entry,
         selected_type,
@@ -1242,6 +1266,8 @@ def _build_control_center_pipe(repo_id, node_state, custom_model=None):
         all_clip_names,
         first_vae_name,
         custom_model=custom_model,
+        custom_clip=custom_clip,
+        custom_vae=custom_vae,
     )
     model, clip = _apply_loras(
         model,

--- a/nodes/vnccs_control_center.py
+++ b/nodes/vnccs_control_center.py
@@ -93,11 +93,64 @@ DEFAULT_MODEL_SCHEDULER = "simple"
 NUNCHAKU_DISABLED_MESSAGE = (
     "Nunchaku support is disabled in VNCCS. Use GGUF models instead."
 )
+CLASSIC_GGUF_FOLDER = "ComfyUI-GGUF"
+GGUF_FORK_WARNING = (
+    "A non-standard GGUF loader is active. Stable VNCCS operation is only tested "
+    "with github.com/city96/ComfyUI-GGUF."
+)
 
 def _get_node_class_mappings():
     import nodes as comfy_nodes
 
     return getattr(comfy_nodes, "NODE_CLASS_MAPPINGS", {})
+
+
+def _get_gguf_loader_class():
+    return _get_node_class_mappings().get("UnetLoaderGGUF")
+
+
+def _describe_gguf_loader(loader_cls=None):
+    loader_cls = loader_cls or _get_gguf_loader_class()
+    if loader_cls is None:
+        return {
+            "available": False,
+            "class_name": None,
+            "module": None,
+            "file": None,
+            "folder": None,
+            "is_classic": False,
+            "warning": None,
+        }
+
+    module_name = getattr(loader_cls, "__module__", "") or ""
+    class_name = getattr(loader_cls, "__name__", "UnetLoaderGGUF")
+    try:
+        loader_file = inspect.getfile(loader_cls)
+    except Exception:
+        loader_file = None
+
+    raw_parts = [part for part in os.path.normpath(loader_file).split(os.sep) if part] if loader_file else []
+    parts = [part.lower() for part in raw_parts]
+    classic_folder = CLASSIC_GGUF_FOLDER.lower()
+    folder = None
+    for index, part in enumerate(parts):
+        if part == "custom_nodes" and index + 1 < len(parts):
+            folder = raw_parts[index + 1]
+            break
+
+    module_tokens = {token for token in re.split(r"[^a-z0-9]+", module_name.lower()) if token}
+    is_classic = classic_folder in parts or module_name.lower() == "comfyui_gguf" or module_tokens == {"comfyui", "gguf"}
+    warning = None if is_classic else GGUF_FORK_WARNING
+
+    return {
+        "available": True,
+        "class_name": class_name,
+        "module": module_name,
+        "file": loader_file,
+        "folder": folder,
+        "is_classic": is_classic,
+        "warning": warning,
+    }
 
 
 def _detect_nunchaku_model_kind(model_entry=None, full_path=""):
@@ -826,15 +879,33 @@ def _load_unet(full_path, settings=None):
 
 
 def _load_gguf(full_path):
-    import nodes as comfy_nodes
-
-    if "UnetLoaderGGUF" not in comfy_nodes.NODE_CLASS_MAPPINGS:
+    loader_cls = _get_gguf_loader_class()
+    if loader_cls is None:
         raise RuntimeError(
             "[VNCCS Control Center] ComfyUI-GGUF not found. Install github.com/city96/ComfyUI-GGUF"
         )
 
-    loader = comfy_nodes.NODE_CLASS_MAPPINGS["UnetLoaderGGUF"]()
-    model, = loader.load_unet(basename_agnostic(full_path))
+    loader_info = _describe_gguf_loader(loader_cls)
+    if loader_info.get("warning"):
+        print(
+            "[VNCCS Control Center] Warning: "
+            f"{loader_info['warning']} Active loader: "
+            f"{loader_info.get('folder') or loader_info.get('module') or loader_info.get('file') or 'unknown'}"
+        )
+
+    loader = loader_cls()
+    try:
+        model, = loader.load_unet(basename_agnostic(full_path))
+    except ValueError as exc:
+        message = str(exc)
+        if "Unexpected architecture type" in message and "qwen_image" in message:
+            active_loader = loader_info.get("folder") or loader_info.get("module") or loader_info.get("file") or "unknown"
+            raise RuntimeError(
+                "[VNCCS Control Center] Installed GGUF loader does not support Qwen Image GGUF files. "
+                "Update github.com/city96/ComfyUI-GGUF and remove or disable older GGUF forks. "
+                f"Active loader: {active_loader}."
+            ) from exc
+        raise
     return model
 
 
@@ -1617,6 +1688,7 @@ async def vnccs_module_status(request):
             "label": "GGUF",
             "github_url": "https://github.com/city96/ComfyUI-GGUF",
             "folders": ["ComfyUI-GGUF"],
+            "loader_check": "gguf",
             "nodes": [
                 {"class_names": ["UnetLoaderGGUF"]},
             ],
@@ -1706,12 +1778,27 @@ async def vnccs_module_status(request):
                 missing_nodes.append(node_spec.get("node_id") or "/".join(node_spec.get("class_names", [])))
 
         if not missing_nodes:
+            extra = {}
+            if spec.get("loader_check") == "gguf":
+                loader_info = _describe_gguf_loader()
+                extra["loader"] = loader_info
+                if loader_info.get("warning"):
+                    return {
+                        "label": spec["label"],
+                        "github_url": spec.get("github_url"),
+                        "status": "warning",
+                        "folder": folders[0] if folders else loader_info.get("folder"),
+                        "missing_nodes": [],
+                        "warning": loader_info["warning"],
+                        **extra,
+                    }
             return {
                 "label": spec["label"],
                 "github_url": spec.get("github_url"),
                 "status": "ok",
                 "folder": folders[0] if folders else None,
                 "missing_nodes": [],
+                **extra,
             }
         return {
             "label": spec["label"],

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "vnccs"
 description = "VNCCS - Visual Novel Character Creation Suite"
-version = "3.0.0"
+version = "3.0.1"
 license = {file = "LICENSE"} 
 
 dependencies = [

--- a/tests/test_character_generator_security.py
+++ b/tests/test_character_generator_security.py
@@ -332,6 +332,7 @@ def test_seedvr_loader_cleans_vram_and_uses_settings(monkeypatch):
             "cache_vae": False,
             "resolution": 4096,
             "max_resolution": 3840,
+            "color_correction": "adain",
         }
     )
 
@@ -349,6 +350,7 @@ def test_seedvr_loader_cleans_vram_and_uses_settings(monkeypatch):
     assert calls[2][0] == "SeedVR2VideoUpscaler"
     assert calls[2][1]["resolution"] == 4096
     assert calls[2][1]["max_resolution"] == 3840
+    assert calls[2][1]["color_correction"] == "adain"
     assert calls[2][1]["offload_device"] == "cpu"
 
 

--- a/tests/test_control_center.py
+++ b/tests/test_control_center.py
@@ -24,6 +24,8 @@ from nodes.vnccs_control_center import (
     _enrich_config_entries,
     _merge_custom_loras,
     _remove_custom_lora,
+    _describe_gguf_loader,
+    _load_gguf,
     VNCCSPipeProxy,
 )
 
@@ -606,3 +608,56 @@ class TestControlCenterRequiredTurboLora:
         )
 
         assert captured["lora_states"] == []
+
+
+class TestGGUFLoaderDiagnostics:
+    def test_describes_classic_loader_without_warning(self, monkeypatch):
+        class OfficialLoader:
+            pass
+
+        monkeypatch.setattr(
+            "nodes.vnccs_control_center.inspect.getfile",
+            lambda cls: "/tmp/ComfyUI/custom_nodes/ComfyUI-GGUF/nodes.py",
+        )
+
+        info = _describe_gguf_loader(OfficialLoader)
+
+        assert info["available"] is True
+        assert info["is_classic"] is True
+        assert info["folder"] == "ComfyUI-GGUF"
+        assert info["warning"] is None
+
+    def test_describes_forked_loader_with_warning(self, monkeypatch):
+        class ForkedLoader:
+            pass
+
+        monkeypatch.setattr(
+            "nodes.vnccs_control_center.inspect.getfile",
+            lambda cls: "/tmp/ComfyUI/custom_nodes/ComfyUI-GGUF_Forked/nodes.py",
+        )
+
+        info = _describe_gguf_loader(ForkedLoader)
+
+        assert info["available"] is True
+        assert info["is_classic"] is False
+        assert info["folder"] == "ComfyUI-GGUF_Forked"
+        assert "non-standard GGUF loader" in info["warning"]
+
+    def test_load_gguf_rewrites_qwen_image_architecture_error(self, monkeypatch):
+        import nodes as comfy_nodes
+
+        class ForkedLoader:
+            def load_unet(self, _name):
+                raise ValueError(
+                    "Unexpected architecture type in GGUF file, expected one of flux, sd1, sdxl, t5encoder "
+                    "but got 'qwen_image'"
+                )
+
+        monkeypatch.setattr(comfy_nodes, "NODE_CLASS_MAPPINGS", {"UnetLoaderGGUF": ForkedLoader}, raising=False)
+        monkeypatch.setattr(
+            "nodes.vnccs_control_center.inspect.getfile",
+            lambda cls: "/tmp/ComfyUI/custom_nodes/ComfyUI-GGUF_Forked/nodes.py",
+        )
+
+        with pytest.raises(RuntimeError, match="does not support Qwen Image GGUF"):
+            _load_gguf("/tmp/Qwen-Image.gguf")

--- a/tests/test_control_center.py
+++ b/tests/test_control_center.py
@@ -413,7 +413,7 @@ class TestVNCCSPipeProxy:
 
 
 class TestControlCenterCustomModel:
-    def test_custom_type_uses_model_input_and_standard_loader(self, monkeypatch):
+    def test_custom_type_uses_external_model_clip_and_vae_inputs(self, monkeypatch):
         custom_model = object()
         custom_clip = object()
         custom_vae = object()
@@ -426,12 +426,24 @@ class TestControlCenterCustomModel:
             "lora": [],
         })
 
-        def fake_load_model_block(model_entry, selected_type, type_settings, config, selected_clips, selected_vae, custom_model=None):
+        def fake_load_model_block(
+            model_entry,
+            selected_type,
+            type_settings,
+            config,
+            selected_clips,
+            selected_vae,
+            custom_model=None,
+            custom_clip=None,
+            custom_vae=None,
+        ):
             assert selected_type == "custom"
             assert model_entry == context_model
             assert custom_model is not None
-            assert selected_clips == ["clip_a"]
-            assert selected_vae == "vae_a"
+            assert custom_clip is not None
+            assert custom_vae is not None
+            assert selected_clips == []
+            assert selected_vae == ""
             return custom_model, custom_clip, custom_vae
 
         monkeypatch.setattr("nodes.vnccs_control_center._load_model_block", fake_load_model_block)
@@ -454,6 +466,8 @@ class TestControlCenterCustomModel:
                 "model_params": {},
             },
             custom_model=custom_model,
+            custom_clip=custom_clip,
+            custom_vae=custom_vae,
         )
 
         assert pipe.model is custom_model
@@ -467,6 +481,41 @@ class TestControlCenterCustomModel:
         assert pipe.sample_steps == 4
         assert pipe.cfg == 1.0
         assert pipe.scheduler == "simple"
+
+    def test_custom_type_requires_external_clip_and_vae_inputs(self, monkeypatch):
+        custom_model = object()
+        custom_clip = object()
+        context_model = {"name": "Qwen GGUF", "type": "gguf", "kind": "QIE2511"}
+
+        monkeypatch.setattr("nodes.vnccs_control_center._get_cc_config", lambda repo_id: {
+            "models": [context_model],
+            "clip": [{"name": "clip_a", "kind": "QIE2511"}],
+            "vae": [{"name": "vae_a", "kind": "QIE2511"}],
+            "lora": [],
+        })
+
+        base_state = {
+            "selected_type": "custom",
+            "selected_models": {"gguf": "Qwen GGUF"},
+            "loras": [],
+            "type_settings": {},
+            "model_params": {},
+        }
+
+        with pytest.raises(RuntimeError, match="Custom CLIP input is not connected"):
+            _build_control_center_pipe(
+                "demo/repo",
+                base_state,
+                custom_model=custom_model,
+            )
+
+        with pytest.raises(RuntimeError, match="Custom VAE input is not connected"):
+            _build_control_center_pipe(
+                "demo/repo",
+                base_state,
+                custom_model=custom_model,
+                custom_clip=custom_clip,
+            )
 
 
 class TestControlCenterRequiredTurboLora:

--- a/web/vnccs_character_creator_v2.js
+++ b/web/vnccs_character_creator_v2.js
@@ -1237,12 +1237,13 @@ app.registerExtension({
                     gen_settings: {
                         generation_mode: "illustrious",
                         ckpt_name: "", sampler: "euler", scheduler: "normal",
-                        steps: 20, cfg: 8.0, seed: generateRandomSeed(), seed_mode: "fixed",
+                        steps: 20, cfg: 8.0, seed: 0, seed_mode: "fixed",
                         diffusion_model_name: "", clip_name: "", vae_name: "",
                         mode_settings: {
                             illustrious: {
                                 ckpt_name: "", sampler: "euler", scheduler: "normal",
-                                steps: 20, cfg: 8.0, seed: generateRandomSeed(), seed_mode: "fixed",
+                                steps: 20, cfg: 8.0, seed: 0, seed_mode: "fixed",
+                                turbo_previous_settings: null,
                                 dmd_lora_name: "", dmd_lora_strength: 1.0,
                                 age_lora_name: "",
                                 lora_stack: [
@@ -1256,7 +1257,7 @@ app.registerExtension({
                             anima: {
                                 diffusion_model_name: "", clip_name: "qwen_3_06b_base.safetensors", vae_name: "qwen_image_vae.safetensors",
                                 sampler: "er_sde", scheduler: "simple",
-                                steps: 30, cfg: 4.0, seed: generateRandomSeed(), seed_mode: "fixed",
+                                steps: 30, cfg: 4.0, seed: 0, seed_mode: "fixed",
                                 turbo_enabled: false,
                                 dmd_lora_name: "anima\\anima-turbo-lora-v0.1.safetensors",
                                 dmd_lora_strength: 1.0,
@@ -1290,7 +1291,8 @@ app.registerExtension({
                 const ANIMA_VAE_NAME = "qwen_image_vae.safetensors";
                 const ILLUSTRIOUS_DEFAULTS = {
                     ckpt_name: "", sampler: "euler", scheduler: "normal",
-                    steps: 20, cfg: 8.0, seed: generateRandomSeed(), seed_mode: "fixed",
+                    steps: 20, cfg: 8.0, seed: 0, seed_mode: "fixed",
+                    turbo_previous_settings: null,
                     dmd_lora_name: "", dmd_lora_strength: 1.0,
                     age_lora_name: "",
                     lora_stack: [
@@ -1304,7 +1306,7 @@ app.registerExtension({
                 const ANIMA_DEFAULTS = {
                     diffusion_model_name: "", clip_name: ANIMA_CLIP_NAME, vae_name: ANIMA_VAE_NAME,
                     sampler: "er_sde", scheduler: "simple",
-                    steps: 30, cfg: 4.0, seed: generateRandomSeed(), seed_mode: "fixed",
+                    steps: 30, cfg: 4.0, seed: 0, seed_mode: "fixed",
                     turbo_enabled: false,
                     dmd_lora_name: ANIMA_TURBO_LORA_NAME,
                     dmd_lora_strength: 1.0,
@@ -1320,7 +1322,7 @@ app.registerExtension({
                 const GENERATION_DEFAULTS_VERSION = 3;
                 const PROMPT_DEFAULTS_VERSION = 1;
                 const MODE_SETTING_KEYS = {
-                    illustrious: ["ckpt_name", "sampler", "scheduler", "steps", "cfg", "seed", "seed_mode", "dmd_lora_name", "dmd_lora_strength", "age_lora_name", "lora_stack"],
+                    illustrious: ["ckpt_name", "sampler", "scheduler", "steps", "cfg", "seed", "seed_mode", "dmd_lora_name", "dmd_lora_strength", "turbo_previous_settings", "age_lora_name", "lora_stack"],
                     anima: ["diffusion_model_name", "clip_name", "vae_name", "sampler", "scheduler", "steps", "cfg", "seed", "seed_mode", "turbo_enabled", "dmd_lora_name", "dmd_lora_strength", "turbo_previous_settings", "lora_stack"],
                 };
                 const MODE_PROMPT_DEFAULTS = {
@@ -1512,7 +1514,7 @@ app.registerExtension({
 
                 const getGenerationDefaults = (mode) => ({
                     ...(mode === "anima" ? ANIMA_DEFAULTS : ILLUSTRIOUS_DEFAULTS),
-                    seed: generateRandomSeed(),
+                    seed: 0,
                 });
 
                 const ensureLoraStack = (profile) => {
@@ -2443,8 +2445,26 @@ app.registerExtension({
                         state.gen_settings.dmd_lora_name = rel || state.gen_settings.dmd_lora_name || "";
                         setAnimaTurboMode(enabled);
                     } else {
-                        state.gen_settings.dmd_lora_name = enabled ? rel : "";
-                        state.gen_settings.dmd_lora_strength = enabled ? 1.0 : 0.0;
+                        if (enabled) {
+                            if ((state.gen_settings.dmd_lora_strength || 0) <= 0) {
+                                state.gen_settings.turbo_previous_settings = {
+                                    steps: state.gen_settings.steps,
+                                    cfg: state.gen_settings.cfg,
+                                };
+                            }
+                            state.gen_settings.dmd_lora_name = rel || state.gen_settings.dmd_lora_name || "";
+                            state.gen_settings.dmd_lora_strength = 1.0;
+                            state.gen_settings.steps = 4;
+                            state.gen_settings.cfg = 1.0;
+                        } else {
+                            state.gen_settings.dmd_lora_name = "";
+                            state.gen_settings.dmd_lora_strength = 0.0;
+                            const previous = state.gen_settings.turbo_previous_settings || {};
+                            if (previous.steps !== undefined) state.gen_settings.steps = previous.steps;
+                            if (previous.cfg !== undefined) state.gen_settings.cfg = previous.cfg;
+                            state.gen_settings.turbo_previous_settings = null;
+                        }
+                        syncGenerationControls();
                         saveState();
                     }
                     renderControlCenterCards();
@@ -3376,7 +3396,24 @@ app.registerExtension({
                     if (mode === "anima") {
                         setAnimaTurboMode(e.target.checked);
                     } else {
-                        state.gen_settings.dmd_lora_strength = e.target.checked ? 1.0 : 0.0;
+                        if (e.target.checked) {
+                            if ((state.gen_settings.dmd_lora_strength || 0) <= 0) {
+                                state.gen_settings.turbo_previous_settings = {
+                                    steps: state.gen_settings.steps,
+                                    cfg: state.gen_settings.cfg,
+                                };
+                            }
+                            state.gen_settings.dmd_lora_strength = 1.0;
+                            state.gen_settings.steps = 4;
+                            state.gen_settings.cfg = 1.0;
+                        } else {
+                            state.gen_settings.dmd_lora_strength = 0.0;
+                            const previous = state.gen_settings.turbo_previous_settings || {};
+                            if (previous.steps !== undefined) state.gen_settings.steps = previous.steps;
+                            if (previous.cfg !== undefined) state.gen_settings.cfg = previous.cfg;
+                            state.gen_settings.turbo_previous_settings = null;
+                        }
+                        syncGenerationControls();
                         saveState();
                     }
                 };
@@ -3587,10 +3624,6 @@ app.registerExtension({
                         applyGenerationProfile(g.generation_mode);
                         migratePromptModes();
 
-                        // Auto-generate seed if still 0 (first use or unset)
-                        if ((!g.seed || g.seed === 0) && g.seed_mode !== "randomize") {
-                            g.seed = generateRandomSeed();
-                        }
                         saveCurrentGenerationModeValues();
                         syncGenerationControls();
                         refreshGenerationModeUI();

--- a/web/vnccs_character_generator.js
+++ b/web/vnccs_character_generator.js
@@ -119,6 +119,7 @@ const WORKFLOW_UPSCALER_VAE_MODELS = [
 ];
 
 const SEEDVR_ATTENTION_MODES = ["sdpa", "flash_attn_2", "flash_attn_3", "sageattn_2", "sageattn_3"];
+const SEEDVR_COLOR_CORRECTION_MODES = ["lab", "wavelet", "wavelet_adaptive", "hsv", "adain", "none"];
 
 const POSE_GENERATION_LORA_LABEL = "VNCCS Pose Studio QIE2511";
 const CLOTHES_CORE_LORA_LABEL = "VNCCS Clothes Core";
@@ -1499,6 +1500,7 @@ class CharacterGeneratorWidget {
             gan_model: "Upscale model used when GAN upscaling is selected.",
             model: "SeedVR diffusion model used for the upscaler stage.",
             resolution: "Output resolution target for SeedVR upscaling.",
+            color_correction: "SeedVR color correction mode. Try adain, wavelet, or none if lab causes color shifts on your GPU.",
             attention_mode: "Attention backend for SeedVR. Auto-detected from installed ComfyUI packages until changed manually.",
             use_internal_rmbg: "Uses the built-in background remover instead of relying only on chroma key.",
             preset: "Strength preset for chroma/background removal.",
@@ -1798,6 +1800,7 @@ class CharacterGeneratorWidget {
             upscalerFields.push(
                 this.field("upscaler", "model", "dit model", "select", this.getWorkflowModelOptions("SeedVR2LoadDiTModel", "model", WORKFLOW_UPSCALER_DIT_MODELS, this.data.upscaler.model)),
                 this.field("upscaler", "resolution", "resolution", "number"),
+                this.field("upscaler", "color_correction", "color correction", "select", this.getOptions("SeedVR2VideoUpscaler", "color_correction", SEEDVR_COLOR_CORRECTION_MODES, this.data.upscaler.color_correction)),
                 this.field("upscaler", "attention_mode", "attention mode", "select", this.getOptions("SeedVR2LoadDiTModel", "attention_mode", this.seedvrAttention.available, this.data.upscaler.attention_mode)),
             );
         }

--- a/web/vnccs_control_center.js
+++ b/web/vnccs_control_center.js
@@ -456,6 +456,108 @@ function _injectVNCCSControlCenterStyles() {
     gap: 6px;
     margin-top: 2px;
 }
+.vnccs-cc-model-inline-section {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    padding: 8px 10px 10px;
+    border-top: 1px solid rgba(255,255,255,0.04);
+    background: rgba(8,8,12,0.42);
+}
+.vnccs-cc-model-inline-label {
+    font-size: 9px;
+    font-weight: 700;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: #ff8fa3;
+    padding: 0 2px;
+}
+.vnccs-cc-turbo-strip {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    min-height: 42px;
+    padding: 0 12px;
+    border-radius: 10px;
+    border: 1px solid rgba(255,255,255,0.08);
+    background: rgba(18,18,26,0.8);
+    transition: border-color 0.16s ease, background 0.16s ease, box-shadow 0.16s ease, transform 0.16s ease;
+    position: relative;
+}
+.vnccs-cc-turbo-strip.is-installed { cursor: pointer; }
+.vnccs-cc-turbo-strip.is-installed:hover {
+    border-color: rgba(255,143,163,0.28);
+    transform: translateY(-1px);
+}
+.vnccs-cc-turbo-strip.is-active {
+    border-color: rgba(255,143,163,0.46);
+    background: linear-gradient(135deg, rgba(255,143,163,0.14) 0%, rgba(0,214,143,0.08) 100%);
+    box-shadow: inset 0 0 0 1px rgba(255,143,163,0.12);
+}
+.vnccs-cc-turbo-strip-name {
+    flex: 1;
+    min-width: 0;
+    font-size: 10.5px;
+    font-weight: 700;
+    color: #e8e8f0;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+.vnccs-cc-turbo-strip-status {
+    font-size: 8.5px;
+    font-weight: 700;
+    letter-spacing: 0.05em;
+    text-transform: uppercase;
+    white-space: nowrap;
+    flex-shrink: 0;
+}
+.vnccs-cc-turbo-strip-status--ok { color: #00d68f; }
+.vnccs-cc-turbo-strip-status--active { color: #ff8fa3; }
+.vnccs-cc-turbo-strip-status--missing { color: #ff4757; }
+.vnccs-cc-turbo-strip-status--progress { color: #b8a9e8; }
+.vnccs-cc-toggle {
+    position: relative;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 34px;
+    height: 20px;
+    flex-shrink: 0;
+}
+.vnccs-cc-toggle input {
+    position: absolute;
+    inset: 0;
+    opacity: 0;
+    cursor: pointer;
+    margin: 0;
+}
+.vnccs-cc-toggle-track {
+    position: absolute;
+    inset: 0;
+    border-radius: 999px;
+    border: 1px solid rgba(255,255,255,0.1);
+    background: rgba(255,255,255,0.08);
+    transition: border-color 0.16s ease, background 0.16s ease;
+}
+.vnccs-cc-toggle-thumb {
+    position: absolute;
+    width: 14px;
+    height: 14px;
+    border-radius: 999px;
+    left: 3px;
+    top: 3px;
+    background: #cfcfe6;
+    transition: transform 0.16s ease, background 0.16s ease;
+}
+.vnccs-cc-toggle input:checked ~ .vnccs-cc-toggle-track {
+    border-color: rgba(255,143,163,0.42);
+    background: rgba(255,143,163,0.16);
+}
+.vnccs-cc-toggle input:checked ~ .vnccs-cc-toggle-thumb {
+    transform: translateX(14px);
+    background: #ff8fa3;
+}
 .vnccs-cc-model-card-footer--stack {
     flex-direction: column;
     align-items: stretch;
@@ -2147,11 +2249,13 @@ class VNCCSControlCenterWidget {
         }
 
         // LORA
-        if (this._isQwenFamily()) {
-            this._renderTurboModelBlock();
-        }
         this._renderLoraBlock();
         this._renderCustomLoraBlock();
+
+        const turboInline = this._buildModelTurboInlineSection();
+        if (turboInline) {
+            this.scrollArea?.querySelector(`.vnccs-cc-block[data-block-key="models"]`)?.appendChild(turboInline);
+        }
 
         // CONTROLNET / OTHER
         this._renderBlock("CONTROLNET", this.config.controlnet, "controlnet",
@@ -2378,11 +2482,7 @@ class VNCCSControlCenterWidget {
     _refreshLoraBlock() {
         if (!this.config) return;
         this._replaceBlock("lora", this._buildLoraBlock());
-        if (this._isQwenFamily()) {
-            this._replaceBlock("turbo_model", this._buildTurboModelBlock());
-        } else {
-            this.scrollArea?.querySelector(`.vnccs-cc-block[data-block-key="turbo_model"]`)?.remove();
-        }
+        this.scrollArea?.querySelector(`.vnccs-cc-block[data-block-key="turbo_model"]`)?.remove();
         this._replaceBlock("custom_lora", this._buildCustomLoraBlock());
     }
 
@@ -2819,6 +2919,98 @@ class VNCCSControlCenterWidget {
         Object.assign(this.state.model_params, patch);
         this._ensureRequiredTurboLora({ persist: false });
         this._saveState();
+        if (this._isQwenFamily()) this._renderAll();
+    }
+
+    _buildModelTurboInlineSection() {
+        const entries = this._compatibleTurboLoras();
+        if (!entries.length) return null;
+
+        const section = document.createElement("div");
+        section.className = "vnccs-cc-model-inline-section";
+
+        const label = document.createElement("div");
+        label.className = "vnccs-cc-model-inline-label";
+        label.textContent = "Turbo LoRA";
+        section.appendChild(label);
+
+        entries.forEach(entry => section.appendChild(this._renderTurboInlineStrip(entry)));
+        return section;
+    }
+
+    _renderTurboInlineStrip(entry) {
+        const ls = (this.state.loras ?? []).find(l => l.name === entry.name)
+            ?? { name: entry.name, auto_apply: false, strength: 1.0 };
+        const dls = this.dlStatus[`cc_lora_${entry.name}`] ?? {};
+        const status = this._resolveStatus(dls.status, entry.status);
+        const installed = status === "installed";
+        const active = installed && ls.auto_apply === true;
+
+        const row = document.createElement("div");
+        row.className = "vnccs-cc-turbo-strip";
+        row.classList.toggle("is-installed", installed);
+        row.classList.toggle("is-active", active);
+        if (installed) {
+            row.onclick = () => this._selectTurboLora(entry.name, !active);
+        }
+
+        row.appendChild(this._badge(status));
+
+        const name = document.createElement("div");
+        name.className = "vnccs-cc-turbo-strip-name";
+        name.textContent = entry.name;
+        row.appendChild(name);
+
+        const statusLbl = document.createElement("div");
+        statusLbl.className = "vnccs-cc-turbo-strip-status";
+        if (installed) {
+            statusLbl.textContent = active ? "Active" : "Installed";
+            statusLbl.classList.add(active ? "vnccs-cc-turbo-strip-status--active" : "vnccs-cc-turbo-strip-status--ok");
+        } else if (status === "downloading" || status === "queued") {
+            statusLbl.textContent = this._statusLabel(status, dls);
+            statusLbl.classList.add("vnccs-cc-turbo-strip-status--progress");
+        } else {
+            statusLbl.textContent = this._statusLabel(status, dls);
+            statusLbl.classList.add("vnccs-cc-turbo-strip-status--missing");
+        }
+        row.appendChild(statusLbl);
+
+        if (installed) {
+            const toggle = document.createElement("label");
+            toggle.className = "vnccs-cc-toggle";
+            toggle.onclick = event => event.stopPropagation();
+            const input = document.createElement("input");
+            input.type = "checkbox";
+            input.checked = active;
+            input.onchange = event => {
+                event.stopPropagation();
+                this._selectTurboLora(entry.name, event.target.checked);
+            };
+            const track = document.createElement("div");
+            track.className = "vnccs-cc-toggle-track";
+            const thumb = document.createElement("div");
+            thumb.className = "vnccs-cc-toggle-thumb";
+            toggle.append(input, track, thumb);
+            row.appendChild(toggle);
+        } else if (status === "auth_required") {
+            const btn = this._btn("⚠ Enter Key", () => this.showApiKeyDialog("lora", entry));
+            btn.style.color = "#ffaa00";
+            btn.style.borderColor = "rgba(255,170,0,0.4)";
+            btn.onclick = event => {
+                event.stopPropagation();
+                this.showApiKeyDialog("lora", entry);
+            };
+            row.appendChild(btn);
+        } else if (this._isDownloadableStatus(status)) {
+            const btn = this._btn(this._downloadLabel(status), () => this._downloadEntry("lora", entry));
+            btn.onclick = event => {
+                event.stopPropagation();
+                this._downloadEntry("lora", entry);
+            };
+            row.appendChild(btn);
+        }
+
+        return row;
     }
 
     _renderModelParams() {
@@ -3141,7 +3333,7 @@ class VNCCSControlCenterWidget {
             }
         }
         this._saveState();
-        this._refreshLoraBlock();
+        this._renderAll();
         this._scheduleDependencyRefresh(true, 120, false);
     }
 

--- a/web/vnccs_control_center.js
+++ b/web/vnccs_control_center.js
@@ -481,13 +481,12 @@ function _injectVNCCSControlCenterStyles() {
     border-radius: 10px;
     border: 1px solid rgba(255,255,255,0.08);
     background: rgba(18,18,26,0.8);
-    transition: border-color 0.16s ease, background 0.16s ease, box-shadow 0.16s ease, transform 0.16s ease;
+    transition: border-color 0.16s ease, background 0.16s ease, box-shadow 0.16s ease;
     position: relative;
 }
 .vnccs-cc-turbo-strip.is-installed { cursor: pointer; }
 .vnccs-cc-turbo-strip.is-installed:hover {
     border-color: rgba(255,143,163,0.28);
-    transform: translateY(-1px);
 }
 .vnccs-cc-turbo-strip.is-active {
     border-color: rgba(255,143,163,0.46);
@@ -1426,13 +1425,6 @@ class VNCCSControlCenterWidget {
         return this._metaType(entry).toLowerCase() === "turbolora";
     }
 
-    _qwenFourStepCfgOne() {
-        const p = this.state.model_params ?? {};
-        const steps = Number(p.steps ?? DEFAULT_MODEL_STEPS);
-        const cfg = Number(p.cfg ?? DEFAULT_MODEL_CFG);
-        return this._isQwenFamily() && steps === 4 && Math.abs(cfg - 1) < 1e-6;
-    }
-
     _compatibleTurboLoras() {
         const selectedKind = this._selectedKind();
         return (this.config?.lora || []).filter(entry =>
@@ -1448,36 +1440,24 @@ class VNCCSControlCenterWidget {
         }) || entries[0] || null;
     }
 
-    _ensureRequiredTurboLora({ persist = true } = {}) {
-        if (!this._qwenFourStepCfgOne()) return false;
-        const turboEntries = this._compatibleTurboLoras();
-        if (!turboEntries.length) return false;
+    _setTurboPreset(enabled) {
+        if (!this.state.model_params) this.state.model_params = {};
+        const params = this.state.model_params;
 
-        const turboNames = new Set(turboEntries.map(entry => entry.name));
-        const alreadyActive = (this.state.loras ?? []).some(lora =>
-            turboNames.has(lora?.name) && lora.auto_apply === true
-        );
-        if (alreadyActive) return false;
-
-        const target = this._preferredTurboLora();
-        if (!target) return false;
-
-        if (!this.state.loras) this.state.loras = [];
-        for (const name of turboNames) {
-            const idx = this.state.loras.findIndex(lora => lora.name === name);
-            if (idx >= 0) {
-                this.state.loras[idx].auto_apply = name === target.name;
-                this.state.loras[idx].strength = 1.0;
-            } else {
-                this.state.loras.push({
-                    name,
-                    auto_apply: name === target.name,
-                    strength: 1.0,
-                });
-            }
+        if (enabled) {
+            params.turbo_previous_settings = {
+                steps: params.steps ?? DEFAULT_MODEL_STEPS,
+                cfg: params.cfg ?? DEFAULT_MODEL_CFG,
+            };
+            params.steps = 4;
+            params.cfg = 1.0;
+            return;
         }
-        if (persist) this._saveState();
-        return true;
+
+        const previous = params.turbo_previous_settings || {};
+        if (previous.steps !== undefined) params.steps = previous.steps;
+        if (previous.cfg !== undefined) params.cfg = previous.cfg;
+        params.turbo_previous_settings = null;
     }
 
     _isHelperLora(entry) {
@@ -2114,7 +2094,6 @@ class VNCCSControlCenterWidget {
             this.config = window.VNCCS_CC_REGISTRY[repoId];
             this.statusText.textContent = this.config.name || "Control Center";
             if (!this.state.output_slot_names) this.state.output_slot_names = [];
-            this._ensureRequiredTurboLora();
             this._renderAll();
             this._dispatchLoraOptions();
         }
@@ -2126,7 +2105,6 @@ class VNCCSControlCenterWidget {
                 this.config = data;
                 this.statusText.textContent = data.name || "Control Center";
                 if (!this.state.output_slot_names) this.state.output_slot_names = [];
-                this._ensureRequiredTurboLora();
                 this._renderAll();
                 this._dispatchLoraOptions();
             } catch { /* already shown by the original caller */ }
@@ -2155,7 +2133,6 @@ class VNCCSControlCenterWidget {
             localStorage.setItem(cacheKey, JSON.stringify(data));
             this._syncCnetSlots(data);
             await this._refreshDependencyStatus(true);
-            this._ensureRequiredTurboLora();
             this._renderAll();
             this._dispatchLoraOptions();
             window.dispatchEvent(new CustomEvent("vnccs-cc-registry-updated", {
@@ -2200,7 +2177,6 @@ class VNCCSControlCenterWidget {
 
     _renderAll() {
         if (!this.config) return;
-        this._ensureRequiredTurboLora();
         this.scrollArea.innerHTML = "";
 
         // TECH DEBT: legacy Nunchaku error rendering disabled. Delete after
@@ -2917,7 +2893,6 @@ class VNCCSControlCenterWidget {
     _modelParamsSave(patch) {
         if (!this.state.model_params) this.state.model_params = {};
         Object.assign(this.state.model_params, patch);
-        this._ensureRequiredTurboLora({ persist: false });
         this._saveState();
         if (this._isQwenFamily()) this._renderAll();
     }
@@ -3318,6 +3293,10 @@ class VNCCSControlCenterWidget {
             .filter(entry => !entry.custom && this._isTurboLora(entry) && this._sameKind(entry, selectedKind))
             .map(entry => entry.name));
 
+        const wasEnabled = (this.state.loras ?? []).some(lora =>
+            turboNames.has(lora?.name) && lora.auto_apply === true
+        );
+
         if (!this.state.loras) this.state.loras = [];
         for (const turboName of turboNames) {
             const idx = this.state.loras.findIndex(lora => lora.name === turboName);
@@ -3332,6 +3311,13 @@ class VNCCSControlCenterWidget {
                 });
             }
         }
+
+        if (enabled && !wasEnabled) {
+            this._setTurboPreset(true);
+        } else if (!enabled && wasEnabled) {
+            this._setTurboPreset(false);
+        }
+
         this._saveState();
         this._renderAll();
         this._scheduleDependencyRefresh(true, 120, false);

--- a/web/vnccs_control_center.js
+++ b/web/vnccs_control_center.js
@@ -1028,6 +1028,11 @@ function _injectVNCCSControlCenterStyles() {
     border-color: rgba(255,170,0,0.25);
     color: #ffaa00;
 }
+.vnccs-cc-pill--warning {
+    background: rgba(255,170,0,0.08);
+    border-color: rgba(255,170,0,0.25);
+    color: #ffaa00;
+}
 .vnccs-cc-update-banner {
     display: flex;
     align-items: center;
@@ -1704,19 +1709,20 @@ class VNCCSControlCenterWidget {
     _makePill(name, version, state, extra = "") {
         const p = document.createElement("span");
         p.className = `vnccs-cc-pill vnccs-cc-pill--${state}`;
-        const icons = { ok: "●", update: "↑", error: "✕", loading: "…", dup: "⚠", partial: "⚠" };
+        const icons = { ok: "●", update: "↑", error: "✕", loading: "…", dup: "⚠", partial: "⚠", warning: "⚠" };
         p.textContent = version
             ? `${name} v${version} ${icons[state] ?? ""}${extra ? " " + extra : ""}`
             : `${name} ${icons[state] ?? ""}${extra ? " " + extra : ""}`;
         if (state === "update") p.title = `Update available: ${extra}`;
         if (state === "dup")   p.title = `Duplicate install detected: ${extra}`;
         if (state === "partial") p.title = extra || "Installed but node classes are not loaded";
+        if (state === "warning") p.title = extra || "Installed with warnings";
         if (state === "error") p.title = extra || "Module not found";
         return p;
     }
 
     _updatePill(pillEl, name, version, state, extra = "") {
-        const icons = { ok: "●", update: "↑", error: "✕", loading: "…", dup: "⚠", partial: "⚠" };
+        const icons = { ok: "●", update: "↑", error: "✕", loading: "…", dup: "⚠", partial: "⚠", warning: "⚠" };
         pillEl.className = `vnccs-cc-pill vnccs-cc-pill--${state}`;
         pillEl.textContent = version
             ? `${name} v${version} ${icons[state] ?? ""}${extra ? " " + extra : ""}`
@@ -1724,6 +1730,7 @@ class VNCCSControlCenterWidget {
         if (state === "update") pillEl.title = `Update available: v${extra}`;
         if (state === "dup")   pillEl.title = `Duplicate install: ${extra}`;
         if (state === "partial") pillEl.title = extra || "Installed but node classes are not loaded";
+        if (state === "warning") pillEl.title = extra || "Installed with warnings";
         if (state === "error") pillEl.title = extra || "Module not found";
     }
 
@@ -1909,10 +1916,16 @@ class VNCCSControlCenterWidget {
             const label = info.label || key;
             const pill = this._ensureDependencyPill(key, label);
             const missing = Array.isArray(info.missing_nodes) ? info.missing_nodes : [];
-            const detail = missing.length ? `missing: ${missing.join(", ")}` : (info.folder ? `folder: ${info.folder}` : "");
+            const loader = info.loader || {};
+            const loaderDetail = loader.folder || loader.module || loader.file || "";
+            const detail = missing.length ? `missing: ${missing.join(", ")}` : (info.warning || (loaderDetail ? `loader: ${loaderDetail}` : (info.folder ? `folder: ${info.folder}` : "")));
             if (info.status === "ok") {
                 this._updatePill(pill, label, null, "ok");
                 pill.title = detail || "Installed";
+            } else if (info.status === "warning") {
+                this._updatePill(pill, label, null, "warning", detail);
+                pill.title = detail || "Installed with warnings";
+                updateNeeded.push(`${label}: ${info.warning || "installed with warnings"}`);
             } else if (info.status === "partial") {
                 this._updatePill(pill, label, null, "partial");
                 pill.title = detail || "installed but not loaded";
@@ -1920,7 +1933,7 @@ class VNCCSControlCenterWidget {
                 this._updatePill(pill, label, null, "error");
                 pill.title = detail || "not installed";
             }
-            if (info.status !== "ok") {
+            if (info.status !== "ok" && info.status !== "warning") {
                 missingDependencies.push({ key, ...info });
             }
         }

--- a/web/vnccs_control_center.js
+++ b/web/vnccs_control_center.js
@@ -1160,22 +1160,37 @@ class VNCCSControlCenterWidget {
         return (this.node.inputs ?? []).findIndex(input => input?.name === "model");
     }
 
+    _getCustomClipInputIndex() {
+        return (this.node.inputs ?? []).findIndex(input => input?.name === "clip");
+    }
+
+    _getCustomVaeInputIndex() {
+        return (this.node.inputs ?? []).findIndex(input => input?.name === "vae");
+    }
+
     _syncCustomModelInput() {
         const selectedType = this.state.selected_type || this._getSelectedType();
-        const inputIndex = this._getCustomModelInputIndex();
+        const isCustom = selectedType === "custom";
 
-        if (selectedType === "custom") {
-            if (inputIndex === -1) {
-                this.node.addInput("model", "MODEL");
-                this.node.setDirtyCanvas(true, true);
+        const sync = (name, type, getIndex, shouldShow) => {
+            const inputIndex = getIndex.call(this);
+            if (shouldShow) {
+                if (inputIndex === -1) {
+                    this.node.addInput(name, type);
+                    this.node.setDirtyCanvas(true, true);
+                }
+                return;
             }
-            return;
-        }
-
-        if (inputIndex !== -1) {
+            if (inputIndex === -1) {
+                return;
+            }
             this.node.removeInput(inputIndex);
             this.node.setDirtyCanvas(true, true);
-        }
+        };
+
+        sync("model", "MODEL", this._getCustomModelInputIndex, isCustom);
+        sync("clip", "CLIP", this._getCustomClipInputIndex, isCustom);
+        sync("vae", "VAE", this._getCustomVaeInputIndex, isCustom);
     }
 
     _setSelectedType(nextType) {
@@ -2113,8 +2128,8 @@ class VNCCSControlCenterWidget {
             isCustom
         );
 
-        // CLIP + VAE — horizontal cards
-        if (!isCP) {
+        // CLIP + VAE — custom mode gets these from external sockets instead.
+        if (!isCP && !isCustom) {
             this._renderClipVaeBlock();
         }
 
@@ -2718,7 +2733,7 @@ class VNCCSControlCenterWidget {
 
         const text = document.createElement("div");
         text.className = "vnccs-cc-model-card-placeholder-text";
-        text.textContent = "Pass-through mode is enabled. Connect the desired model to the node input.";
+        text.textContent = "Pass-through mode is enabled. Connect MODEL, CLIP, and VAE to the node inputs.";
         card.appendChild(text);
 
         return card;

--- a/web/vnccs_emotion_v2.js
+++ b/web/vnccs_emotion_v2.js
@@ -2189,8 +2189,12 @@ app.registerExtension({
                         });
                     }
                     charSelect.onchange = () => {
+                        const previousCharacter = state.character;
                         state.character = charSelect.value;
                         commitWidget(charWidget, charSelect.value, false);
+                        if (charSelect.value !== previousCharacter) {
+                            resetSelectedEmotionsForCharacterChange();
+                        }
                         fetchCharacterData(charSelect.value);
                     };
                     charWidget.hidden = true;
@@ -2647,6 +2651,12 @@ app.registerExtension({
                     updateButtonState();
                 }
 
+                function resetSelectedEmotionsForCharacterChange() {
+                    state.selectedEmotions = new Set();
+                    updateEmotionsData();
+                    renderEmotions();
+                }
+
                 function createEmotionCard(e, compact = false) {
                     const div = document.createElement("div");
                     const selected = state.selectedEmotions.has(e.safe_name);
@@ -2827,8 +2837,12 @@ app.registerExtension({
                 if (charWidget) {
                     const originalCb = charWidget.callback;
                     charWidget.callback = function (v) {
+                        const previousCharacter = state.character;
                         state.character = v;
                         if (charSelect.value !== v) charSelect.value = v;
+                        if (v !== previousCharacter) {
+                            resetSelectedEmotionsForCharacterChange();
+                        }
                         fetchCharacterData(v);
                         if (originalCb) originalCb(v);
                     };

--- a/web/vnccs_emotion_v2.js
+++ b/web/vnccs_emotion_v2.js
@@ -1046,6 +1046,7 @@ app.registerExtension({
         app.queuePrompt = async function(...args) {
             const nodes = app.graph?._nodes?.filter(n => n.type === "EmotionGeneratorV2") || [];
             for (const node of nodes) {
+                node._randomizeSeedIfNeeded?.();
                 if (node._validateBeforeQueue && !node._validateBeforeQueue()) {
                     return; // block queue, modal already shown inside _validateBeforeQueue
                 }
@@ -1084,7 +1085,7 @@ app.registerExtension({
                 const ANIMA_CLIP_NAME = "qwen_3_06b_base.safetensors";
                 const ANIMA_VAE_NAME = "qwen_image_vae.safetensors";
                 const promptStyleForMode = (mode) => String(mode || "anima").toLowerCase() === "anima" ? "Anima" : "SDXL Style";
-                const initialSharedSeed = generateRandomSeed();
+                const initialSharedSeed = 0;
                 const GENERATION_DEFAULTS = {
                     generation_mode: "anima",
                     ckpt_name: "",
@@ -1176,6 +1177,14 @@ app.registerExtension({
                     loras: [],
                 };
                 const modelPickerOpen = { illustrious: false, anima: false };
+
+                node._randomizeSeedIfNeeded = () => {
+                    if ((state.gen.seed_mode || "fixed") === "randomize") {
+                        state.gen.seed = generateRandomSeed();
+                        if (generationEls.seed) generationEls.seed.value = state.gen.seed;
+                        saveGenerationSettings(false);
+                    }
+                };
 
                 const ccNormalize = (value) => String(value || "").trim().toLowerCase();
                 const ccKind = (entry) => ccNormalize(entry?.kind ?? entry?.Kind);
@@ -1876,7 +1885,12 @@ app.registerExtension({
                     if (generationEls.sampler) generationEls.sampler.value = state.gen.sampler || "euler";
                     if (generationEls.scheduler) generationEls.scheduler.value = state.gen.scheduler || "normal";
                     if (generationEls.seed) generationEls.seed.value = state.gen.seed ?? 0;
-                    if (generationEls.seedMode) generationEls.seedMode.classList.toggle("active", (state.gen.seed_mode || "fixed") === "randomize");
+                    if (generationEls.seedMode) {
+                        const randomize = (state.gen.seed_mode || "fixed") === "randomize";
+                        generationEls.seedMode.classList.toggle("active", randomize);
+                        generationEls.seedMode.title = randomize ? "Random seed on queue" : "Fixed seed";
+                        generationEls.seedMode.setAttribute("aria-pressed", randomize ? "true" : "false");
+                    }
                     if (generationEls.loraHeader) generationEls.loraHeader.innerText = mode === "anima" ? "Anima LoRA Stack" : "Illustrious LoRA Stack";
                     if (generationEls.loraSection) generationEls.loraSection.style.display = "flex";
                     if (generationEls.animaLoraCards) renderModeLoraCards(generationEls.animaLoraCards, mode);
@@ -2117,7 +2131,6 @@ app.registerExtension({
                 </svg>`;
                 seedDice.onclick = () => {
                     state.gen.seed_mode = (state.gen.seed_mode || "fixed") === "randomize" ? "fixed" : "randomize";
-                    if (state.gen.seed_mode === "randomize") state.gen.seed = generateRandomSeed();
                     syncGenerationControls();
                     saveGenerationSettings();
                 };

--- a/web/vnccs_emotion_v2.js
+++ b/web/vnccs_emotion_v2.js
@@ -1083,6 +1083,7 @@ app.registerExtension({
                 const ANIMA_TURBO_LORA_NAME = "anima\\anima-turbo-lora-v0.1.safetensors";
                 const ANIMA_CLIP_NAME = "qwen_3_06b_base.safetensors";
                 const ANIMA_VAE_NAME = "qwen_image_vae.safetensors";
+                const promptStyleForMode = (mode) => String(mode || "anima").toLowerCase() === "anima" ? "Anima" : "SDXL Style";
                 const GENERATION_DEFAULTS = {
                     generation_mode: "anima",
                     ckpt_name: "",
@@ -1249,7 +1250,7 @@ app.registerExtension({
 
                 function persistAllState() {
                     commitWidget(charWidget, state.character, false);
-                    if (styleWidget) commitWidget(styleWidget, styleSelect.value, false);
+                    if (styleWidget) commitWidget(styleWidget, promptStyleForMode(state.gen.generation_mode), false);
                     if (costumesDataWidget) commitWidget(costumesDataWidget, JSON.stringify(Array.from(state.selectedCostumes)), false);
                     if (emotionsDataWidget) commitWidget(emotionsDataWidget, JSON.stringify(Array.from(state.selectedEmotions)), false);
                     saveGenerationSettings(false);
@@ -1264,6 +1265,7 @@ app.registerExtension({
 
                     commitWidget(generationSettingsWidget, JSON.stringify(state.gen), callCallback);
                     commitWidget(modelWidget, mode === "anima" ? "Anima" : "Illustrious", callCallback);
+                    if (styleWidget) commitWidget(styleWidget, promptStyleForMode(mode), callCallback);
                     window.dispatchEvent(new CustomEvent("vnccs-emotion-studio-generation-mode-changed"));
                 }
 
@@ -1522,7 +1524,7 @@ app.registerExtension({
                     scheduler: "Noise schedule used together with the sampler.",
                     seed: "Numeric seed for reproducible emotion generations.",
                     seed_mode: "Toggles fixed seed versus a fresh random seed for each generation.",
-                    lora_stack: "Additional Anima LoRAs mixed into emotion generation.",
+                    lora_stack: "Additional LoRAs mixed into emotion generation for the selected model mode.",
                     lora_strength: "Strength of the LoRA in this row."
                 };
                 const helpFor = (key, fallback = "") => FIELD_HELP[key] || fallback;
@@ -1834,7 +1836,9 @@ app.registerExtension({
                     if (generationEls.scheduler) generationEls.scheduler.value = state.gen.scheduler || "normal";
                     if (generationEls.seed) generationEls.seed.value = state.gen.seed ?? 0;
                     if (generationEls.seedMode) generationEls.seedMode.classList.toggle("active", (state.gen.seed_mode || "fixed") === "randomize");
-                    if (generationEls.loraSection) generationEls.loraSection.style.display = mode === "anima" ? "flex" : "none";
+                    if (generationEls.loraHeader) generationEls.loraHeader.innerText = mode === "anima" ? "Anima LoRA Stack" : "Illustrious LoRA Stack";
+                    if (generationEls.loraSection) generationEls.loraSection.style.display = "flex";
+                    if (generationEls.animaLoraCards) renderModeLoraCards(generationEls.animaLoraCards, mode);
                     if (generationEls.loraRows) {
                         generationEls.loraRows.forEach((row, index) => {
                             const item = (state.gen.lora_stack || [])[index] || { name: "", strength: 1.0 };
@@ -2091,6 +2095,7 @@ app.registerExtension({
                 const loraHeader = document.createElement("div");
                 loraHeader.className = "ems-costumes-header";
                 loraHeader.innerText = "Anima LoRA Stack";
+                generationEls.loraHeader = loraHeader;
                 loraSection.appendChild(loraHeader);
                 const animaLoraCards = document.createElement("div");
                 animaLoraCards.className = "ems-lora-stack";
@@ -2210,44 +2215,11 @@ app.registerExtension({
                     window.removeEventListener("vnccs.migration.complete", onCharactersUpdated);
                 });
 
-                // Add Prompt Style Select (Top)
                 const styleWidget = node.widgets.find(w => w.name === "prompt_style");
-                const normalizePromptStyle = (value) => value === "QWEN Style" ? "Anima" : value;
-
-                const styleContainer = document.createElement("div");
-                styleContainer.className = "ems-section";
-                styleContainer.style.marginBottom = "10px";
-                styleContainer.style.padding = "5px 10px";
-
-                const styleSelect = document.createElement("select");
-                styleSelect.className = "em-select";
-
-                if (styleWidget && styleWidget.options.values) {
-                    const seenStyles = new Set();
-                    styleWidget.options.values.forEach(v => {
-                        const normalized = normalizePromptStyle(v);
-                        if (seenStyles.has(normalized)) return;
-                        seenStyles.add(normalized);
-                        const opt = document.createElement("option");
-                        opt.value = normalized;
-                        opt.innerText = normalized;
-                        if (normalized === normalizePromptStyle(styleWidget.value)) opt.selected = true;
-                        styleSelect.appendChild(opt);
-                    });
-                    if (styleWidget.value !== normalizePromptStyle(styleWidget.value)) {
-                        commitWidget(styleWidget, normalizePromptStyle(styleWidget.value), false);
-                    }
-                    // Sync
-                    styleSelect.onchange = () => {
-                        commitWidget(styleWidget, normalizePromptStyle(styleSelect.value));
-                    };
+                if (styleWidget) {
                     styleWidget.hidden = true;
+                    commitWidget(styleWidget, promptStyleForMode(state.gen.generation_mode), false);
                 }
-                styleContainer.appendChild(styleSelect);
-
-                // Insert Style Container at the TOP of Left Col
-                // Currently Left Col has charSection. We can prepend.
-                leftCol.prepend(styleContainer);
 
 
                 enableMiddleMouseCanvasPan(container);
@@ -2511,24 +2483,13 @@ app.registerExtension({
                         fetchCharacterData(state.character);
                     }
 
-                    // 2. Style
-                    if (styleWidget && styleWidget.value) {
-                        const normalizedStyle = normalizePromptStyle(styleWidget.value);
-                        if (![...styleSelect.options].some(opt => opt.value === normalizedStyle)) {
-                            const opt = document.createElement("option");
-                            opt.value = normalizedStyle;
-                            opt.innerText = normalizedStyle;
-                            styleSelect.appendChild(opt);
-                        }
-                        styleSelect.value = normalizedStyle;
-                        if (styleWidget.value !== normalizedStyle) commitWidget(styleWidget, normalizedStyle, false);
-                    }
                     if (modelWidget && modelWidget.value) {
                         state.gen.generation_mode = String(modelWidget.value).toLowerCase();
                     }
                     if (generationSettingsWidget && generationSettingsWidget.value) {
                         state.gen = parseGenerationSettings();
                     }
+                    if (styleWidget) commitWidget(styleWidget, promptStyleForMode(state.gen.generation_mode), false);
                     syncGenerationControls();
 
                     // 3. Costumes & Emotions (from hidden text strings)
@@ -2786,8 +2747,6 @@ app.registerExtension({
                         if (token !== characterFetchToken || charName !== state.character) return;
                         state.costumes = validCostumes || [];
 
-                        // FIX: Only reset to "all" if no saved selection exists
-                        // Otherwise, filter saved selection to only include valid costumes
                         if (costumesDataWidget && costumesDataWidget.value) {
                             try {
                                 const saved = JSON.parse(costumesDataWidget.value);

--- a/web/vnccs_emotion_v2.js
+++ b/web/vnccs_emotion_v2.js
@@ -1084,6 +1084,7 @@ app.registerExtension({
                 const ANIMA_CLIP_NAME = "qwen_3_06b_base.safetensors";
                 const ANIMA_VAE_NAME = "qwen_image_vae.safetensors";
                 const promptStyleForMode = (mode) => String(mode || "anima").toLowerCase() === "anima" ? "Anima" : "SDXL Style";
+                const initialSharedSeed = generateRandomSeed();
                 const GENERATION_DEFAULTS = {
                     generation_mode: "anima",
                     ckpt_name: "",
@@ -1095,7 +1096,7 @@ app.registerExtension({
                     scheduler: "simple",
                     steps: 30,
                     cfg: 4.0,
-                    seed: generateRandomSeed(),
+                    seed: initialSharedSeed,
                     seed_mode: "fixed",
                     turbo_enabled: false,
                     turbo_previous_settings: null,
@@ -1111,7 +1112,8 @@ app.registerExtension({
                     mode_settings: {
                         illustrious: {
                             ckpt_name: "", sampler: "euler", scheduler: "normal",
-                            steps: 20, cfg: 8.0, seed: generateRandomSeed(), seed_mode: "fixed",
+                            steps: 20, cfg: 8.0, seed: initialSharedSeed, seed_mode: "fixed",
+                            turbo_previous_settings: null,
                             dmd_lora_name: "", dmd_lora_strength: 1.0,
                             lora_stack: [
                                 { name: "", strength: 1.0 },
@@ -1124,7 +1126,7 @@ app.registerExtension({
                         anima: {
                             diffusion_model_name: "", clip_name: ANIMA_CLIP_NAME, vae_name: ANIMA_VAE_NAME,
                             clip_type: "stable_diffusion", sampler: "er_sde", scheduler: "simple",
-                            steps: 30, cfg: 4.0, seed: generateRandomSeed(), seed_mode: "fixed",
+                            steps: 30, cfg: 4.0, seed: initialSharedSeed, seed_mode: "fixed",
                             turbo_enabled: false, turbo_previous_settings: null,
                             dmd_lora_name: ANIMA_TURBO_LORA_NAME, dmd_lora_strength: 1.0,
                             lora_stack: [
@@ -1259,9 +1261,21 @@ app.registerExtension({
                 function saveGenerationSettings() {
                     const callCallback = arguments.length > 0 ? arguments[0] : true;
                     const mode = (state.gen.generation_mode || "anima").toLowerCase();
+                    const sharedSeed = state.gen.seed ?? initialSharedSeed;
+                    const sharedSeedMode = state.gen.seed_mode || "fixed";
                     state.gen.mode_settings = state.gen.mode_settings || {};
+                    state.gen.seed = sharedSeed;
+                    state.gen.seed_mode = sharedSeedMode;
                     state.gen.mode_settings[mode] = { ...state.gen };
                     delete state.gen.mode_settings[mode].mode_settings;
+                    for (const profileMode of ["illustrious", "anima"]) {
+                        const profile = state.gen.mode_settings[profileMode] || { ...GENERATION_DEFAULTS.mode_settings[profileMode] };
+                        state.gen.mode_settings[profileMode] = {
+                            ...profile,
+                            seed: sharedSeed,
+                            seed_mode: sharedSeedMode,
+                        };
+                    }
 
                     commitWidget(generationSettingsWidget, JSON.stringify(state.gen), callCallback);
                     commitWidget(modelWidget, mode === "anima" ? "Anima" : "Illustrious", callCallback);
@@ -1272,12 +1286,21 @@ app.registerExtension({
                 function setGenerationMode(mode) {
                     mode = mode === "illustrious" ? "illustrious" : "anima";
                     const current = (state.gen.generation_mode || "anima").toLowerCase();
+                    const sharedSeed = state.gen.seed ?? initialSharedSeed;
+                    const sharedSeedMode = state.gen.seed_mode || "fixed";
                     state.gen.mode_settings = state.gen.mode_settings || {};
                     state.gen.mode_settings[current] = { ...state.gen };
                     delete state.gen.mode_settings[current].mode_settings;
 
                     const profile = state.gen.mode_settings[mode] || GENERATION_DEFAULTS.mode_settings[mode] || {};
-                    state.gen = { ...GENERATION_DEFAULTS, ...profile, mode_settings: state.gen.mode_settings, generation_mode: mode };
+                    state.gen = {
+                        ...GENERATION_DEFAULTS,
+                        ...profile,
+                        mode_settings: state.gen.mode_settings,
+                        generation_mode: mode,
+                        seed: sharedSeed,
+                        seed_mode: sharedSeedMode,
+                    };
                     syncGenerationControls();
                     saveGenerationSettings();
                 }
@@ -1441,8 +1464,26 @@ app.registerExtension({
                         state.gen.dmd_lora_name = rel || state.gen.dmd_lora_name || "";
                         setAnimaTurboMode(enabled, rel || state.gen.dmd_lora_name || ANIMA_TURBO_LORA_NAME);
                     } else {
-                        state.gen.dmd_lora_name = enabled ? rel : "";
-                        state.gen.dmd_lora_strength = enabled ? 1.0 : 0.0;
+                        if (enabled) {
+                            if ((state.gen.dmd_lora_strength || 0) <= 0) {
+                                state.gen.turbo_previous_settings = {
+                                    steps: state.gen.steps,
+                                    cfg: state.gen.cfg,
+                                };
+                            }
+                            state.gen.dmd_lora_name = rel || state.gen.dmd_lora_name || "";
+                            state.gen.dmd_lora_strength = 1.0;
+                            state.gen.steps = 4;
+                            state.gen.cfg = 1.0;
+                        } else {
+                            state.gen.dmd_lora_name = "";
+                            state.gen.dmd_lora_strength = 0.0;
+                            const previous = state.gen.turbo_previous_settings || {};
+                            if (previous.steps !== undefined) state.gen.steps = previous.steps;
+                            if (previous.cfg !== undefined) state.gen.cfg = previous.cfg;
+                            state.gen.turbo_previous_settings = null;
+                        }
+                        syncGenerationControls();
                         saveGenerationSettings();
                     }
                     renderControlCenterCards();


### PR DESCRIPTION
# VNCCS 3.0.1 Changelog

This changelog describes the user-visible changes in version `3.0.1` compared with `3.0.0`.
It focuses on workflow behavior and UI changes, not internal refactors.

## Headline Changes

- SeedVR upscaling now exposes a color-correction selector in the generator UI.
- Emotion Studio and Character Creator V2 now use the same seed behavior as Clothes Designer: `seed = 0` can stay fixed, and randomization happens on queue only when random mode is enabled.
- Illustrious turbo mode now works consistently across Emotion Studio, Character Creator V2, and Control Center: enabling turbo sets `steps = 4` and `cfg = 1`, disabling it restores the previous values.
- Emotion Studio no longer uses a separate prompt-style selector in the widget header; prompt style is now derived automatically from the selected generation model.
- Control Center now shows Turbo LoRA as an inline selector in the `MODEL` section instead of a separate `Turbo Model` card.

## Character Generator

- Added a SeedVR color-correction selector with multiple modes such as `lab`, `adain`, `wavelet`, and `none`.
- Added help text so users can more easily switch away from `lab` when a GPU produces unwanted color shifts.

## Emotion Studio

- Removed the old top-left prompt-style selector from the widget.
- Prompt style is now chosen automatically from the selected generation mode: `Anima` mode uses the Anima prompt path, while `Illustrious` mode uses the SDXL-style prompt path.
- The seed field is now shared between Anima and Illustrious profiles so both modes show and use the same seed.
- Random seed mode now generates a new seed only when the workflow is queued, instead of rewriting the seed immediately in the UI.
- The Illustrious turbo toggle now stores the previous `steps/cfg`, switches to `4 / 1` while enabled, and restores the saved values when disabled.
- The LoRA section now stays available for both generation modes and updates its header and card set to match the active mode.

## Character Creator V2

- Seed handling now matches Clothes Designer semantics more closely.
- Default generation seed values are now initialized to `0` in fixed mode instead of being auto-randomized.
- Backend seed resolution now respects `seed_mode`, which keeps preview generation, pipe generation, and sampler execution consistent.
- The Illustrious turbo toggle now behaves like the other updated widgets: it saves previous `steps/cfg`, applies `4 / 1` while active, and restores the earlier values when turned off.

## Control Center

- `CUSTOM` pass-through mode now expects external `MODEL`, `CLIP`, and `VAE` inputs together, instead of showing the normal internal CLIP/VAE asset cards.
- Turbo LoRA has been moved into the `MODEL` block as a flat inline selector under the model and parameter area.
- The old standalone `Turbo Model` section has been removed.
- Turbo is no longer force-enabled just because `steps/cfg` happen to be `4 / 1`.
- Toggling Turbo LoRA on now saves the current `steps/cfg` and applies `4 / 1`; toggling it off restores the saved values.
- Hovering the Turbo LoRA selector no longer makes the toggle visually jump.
- Dependency/setup status can now show warning states more clearly instead of treating every non-OK condition as a hard failure.