### PR TITLE
3.0.2

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -16,20 +16,11 @@ The release focuses on Clothes Designer preview execution, Control Center catalo
 - Custom previews now use the model stack and settings supplied through the connected Control Center pipe.
 - Preview generation waits for the `vnccs.preview.updated` event before refreshing the displayed image.
 - Execution errors, interruptions, and preview timeouts are now reported by the Clothes Designer UI.
-- Costume state is saved before preview execution begins, preventing the queued workflow from using stale widget data.
 - Clothes Designer is now marked as an output node so ComfyUI accepts it as the destination of partial graph execution.
-- A generated custom preview now preserves its source-sprite input signature, allowing the following full workflow run to reuse the preview cache instead of generating the same image again.
-- Repeating a cached custom preview now completes immediately instead of leaving the `Generating preview` overlay active while ComfyUI reports a `0.00 seconds` execution.
 
 ## Control Center and Model Catalog
 
 - Updated the packaged `control_center.json` to match the current remote catalog.
-- Added six Qwen Image Edit 2511 Nunchaku model variants:
-  - Balance FP4 and INT4.
-  - Best Quality FP4 and INT4.
-  - Ultimate Speed FP4 and INT4.
-- Updated the active `VNCCS Clothes Core` catalog entry to `RC3.7` (`0.3.7`).
-- Removed the obsolete `VNCCS Emotion Core` entry from the current catalog.
 - A successfully downloaded Control Center catalog is now written back to the packaged fallback file, preventing an older bundled catalog from reappearing after model updates or remote access failures.
 - Packaged catalog updates use a lock and atomic file replacement so concurrent reads cannot observe a partially written JSON file.
 - The packaged file is left untouched when the downloaded catalog has not changed, and synchronization failures no longer prevent Control Center from using the downloaded data.

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,56 @@
+# VNCCS 3.0.2 Changelog
+
+This changelog describes the changes in version `3.0.2` compared with `3.0.1`.
+The release focuses on Clothes Designer preview execution, Control Center catalog freshness, and SAM3 batch stability.
+
+## Headline Changes
+
+- Clothes Designer previews now work with the `CUSTOM` Control Center configuration by executing the connected workflow branch, so externally supplied `MODEL`, `CLIP`, and `VAE` inputs are used correctly.
+- Clothes Designer is now a valid ComfyUI partial-execution target, fixing the `Prompt has no outputs` error when generating a custom preview.
+- SAM3 detail recovery now processes image batches one image at a time, fixing tensor-stack failures when different images produce different numbers of detections.
+- The bundled Control Center catalog has been updated to the current model list and is automatically refreshed after a newer catalog is loaded from Hugging Face.
+
+## Clothes Designer
+
+- `Generate Preview` in `CUSTOM` mode now queues only the graph required to execute the connected Clothes Designer node instead of calling the standalone preview endpoint.
+- Custom previews now use the model stack and settings supplied through the connected Control Center pipe.
+- Preview generation waits for the `vnccs.preview.updated` event before refreshing the displayed image.
+- Execution errors, interruptions, and preview timeouts are now reported by the Clothes Designer UI.
+- Costume state is saved before preview execution begins, preventing the queued workflow from using stale widget data.
+- Clothes Designer is now marked as an output node so ComfyUI accepts it as the destination of partial graph execution.
+- A generated custom preview now preserves its source-sprite input signature, allowing the following full workflow run to reuse the preview cache instead of generating the same image again.
+- Repeating a cached custom preview now completes immediately instead of leaving the `Generating preview` overlay active while ComfyUI reports a `0.00 seconds` execution.
+
+## Control Center and Model Catalog
+
+- Updated the packaged `control_center.json` to match the current remote catalog.
+- Added six Qwen Image Edit 2511 Nunchaku model variants:
+  - Balance FP4 and INT4.
+  - Best Quality FP4 and INT4.
+  - Ultimate Speed FP4 and INT4.
+- Updated the active `VNCCS Clothes Core` catalog entry to `RC3.7` (`0.3.7`).
+- Removed the obsolete `VNCCS Emotion Core` entry from the current catalog.
+- A successfully downloaded Control Center catalog is now written back to the packaged fallback file, preventing an older bundled catalog from reappearing after model updates or remote access failures.
+- Packaged catalog updates use a lock and atomic file replacement so concurrent reads cannot observe a partially written JSON file.
+- The packaged file is left untouched when the downloaded catalog has not changed, and synchronization failures no longer prevent Control Center from using the downloaded data.
+
+## Chroma Key and SAM3 Recovery
+
+- SAM3 recovery segmentation now runs separately for every image in a batch.
+- This avoids `torch.stack` failures in Easy SAM3 when detection-box counts or shapes differ between batch items.
+- The SAM3 model is loaded once, retained between images, and released after the final image in the batch.
+- Recovered masks are normalized per image and concatenated back into the original batch order.
+
+## Reliability and Maintenance
+
+- Added regression coverage for atomic packaged-catalog synchronization and remote catalog refresh.
+- Added checks that the bundled catalog selects Clothes Core `0.3.7` and no longer exposes the obsolete Emotion Core entry.
+- Added frontend contract coverage for custom partial preview execution.
+- Added a regression check that Clothes Designer remains a valid output target.
+- Added batch recovery coverage that reproduces the variable-detection SAM3 failure.
+- Updated test environment model-path stubs for the current Control Center behavior.
+- Updated package version metadata from `3.0.1` to `3.0.2`.
+
 # VNCCS 3.0.1 Changelog
 
 This changelog describes the user-visible changes in version `3.0.1` compared with `3.0.0`.
@@ -167,4 +220,3 @@ It focuses on workflow and system behavior, not on internal code changes.
 - Old character sheets can be converted into the new sprite-based format.
 - Migration can also repair sprite canvas mismatches so old assets behave better in the new workflow.
 - Users are expected to verify migrated characters before deleting old folders.
-

--- a/control_center.json
+++ b/control_center.json
@@ -32,6 +32,66 @@
       "kind": "QIE2511"
     },
     {
+      "name": "Qwen-Image-Edit-2511-nunchaku-balance-fp4",
+      "type": "nunchaku",
+      "hf_repo": "QuantFunc/Nunchaku-Qwen-Image-EDIT-2511",
+      "hf_path": "nunchaku_qwen_image_edit_2511_balance_fp4.safetensors",
+      "local_path": "models/diffusion_models/nunchaku_qwen_image_edit_2511_balance_fp4.safetensors",
+      "version": "1.0",
+      "description": "(NVIDIA 5xxx series ONLY) Nunchaku Balance FP4 — balanced quality/speed.",
+      "kind": "QIE2511"
+    },
+    {
+      "name": "Qwen-Image-Edit-2511-nunchaku-balance-int4",
+      "type": "nunchaku",
+      "hf_repo": "QuantFunc/Nunchaku-Qwen-Image-EDIT-2511",
+      "hf_path": "nunchaku_qwen_image_edit_2511_balance_int4.safetensors",
+      "local_path": "models/diffusion_models/nunchaku_qwen_image_edit_2511_balance_int4.safetensors",
+      "version": "1.0",
+      "description": "(NVIDIA 4xxx and lower) Nunchaku Balance INT4 — balanced quality/speed.",
+      "kind": "QIE2511"
+    },
+    {
+      "name": "Qwen-Image-Edit-2511-nunchaku-best-quality-fp4",
+      "type": "nunchaku",
+      "hf_repo": "QuantFunc/Nunchaku-Qwen-Image-EDIT-2511",
+      "hf_path": "nunchaku_qwen_image_edit_2511_best_quality_fp4.safetensors",
+      "local_path": "models/diffusion_models/nunchaku_qwen_image_edit_2511_best_quality_fp4.safetensors",
+      "version": "1.0",
+      "description": "(NVIDIA 5xxx series ONLY) Nunchaku Best Quality FP4 — highest quality, higher VRAM.",
+      "kind": "QIE2511"
+    },
+    {
+      "name": "Qwen-Image-Edit-2511-nunchaku-best-quality-int4",
+      "type": "nunchaku",
+      "hf_repo": "QuantFunc/Nunchaku-Qwen-Image-EDIT-2511",
+      "hf_path": "nunchaku_qwen_image_edit_2511_best_quality_int4.safetensors",
+      "local_path": "models/diffusion_models/nunchaku_qwen_image_edit_2511_best_quality_int4.safetensors",
+      "version": "1.0",
+      "description": "(NVIDIA 4xxx and lower) Nunchaku Best Quality INT4 — highest quality, higher VRAM.",
+      "kind": "QIE2511"
+    },
+    {
+      "name": "Qwen-Image-Edit-2511-nunchaku-ultimate-speed-fp4",
+      "type": "nunchaku",
+      "hf_repo": "QuantFunc/Nunchaku-Qwen-Image-EDIT-2511",
+      "hf_path": "nunchaku_qwen_image_edit_2511_ultimate_speed_fp4.safetensors",
+      "local_path": "models/diffusion_models/nunchaku_qwen_image_edit_2511_ultimate_speed_fp4.safetensors",
+      "version": "1.0",
+      "description": "(NVIDIA 5xxx series ONLY) Nunchaku Ultimate Speed FP4 — fastest inference, lower VRAM.",
+      "kind": "QIE2511"
+    },
+    {
+      "name": "Qwen-Image-Edit-2511-nunchaku-ultimate-speed-int4",
+      "type": "nunchaku",
+      "hf_repo": "QuantFunc/Nunchaku-Qwen-Image-EDIT-2511",
+      "hf_path": "nunchaku_qwen_image_edit_2511_ultimate_speed_int4.safetensors",
+      "local_path": "models/diffusion_models/nunchaku_qwen_image_edit_2511_ultimate_speed_int4.safetensors",
+      "version": "1.0",
+      "description": "(NVIDIA 4xxx and lower) Nunchaku Ultimate Speed INT4 — fastest inference, lower VRAM.",
+      "kind": "QIE2511"
+    },
+    {
       "name": "Qwen-Image-Edit-2511-NVFP4",
       "type": "unet",
       "hf_repo": "Bedovyy/Qwen-Image-Edit-2511-NVFP4",
@@ -132,6 +192,16 @@
     {
       "name": "VNCCS Clothes Core",
       "hf_repo": "MIUProject/VNCCS_v3.0",
+      "hf_path": "models/loras/qwen/VNCCS/VNCCS_QIE2511_ClothesCore-RC3.safetensors",
+      "local_path": "models/loras/qwen/VNCCS/VNCCS_QIE2511_ClothesCore-RC3.safetensors",
+      "version": "0.3.0",
+      "description": "Helps maintain clothing consistency.",
+      "type": "Helper",
+      "kind": "QIE2511"
+    },
+    {
+      "name": "VNCCS Clothes Core",
+      "hf_repo": "MIUProject/VNCCS_v3.0",
       "hf_path": "models/loras/qwen/VNCCS/VNCCS_QIE2511_ClothesCore-RC3.5.safetensors",
       "local_path": "models/loras/qwen/VNCCS/VNCCS_QIE2511_ClothesCore-RC3.5.safetensors",
       "version": "0.3.5",
@@ -140,12 +210,22 @@
       "kind": "QIE2511"
     },
     {
-      "name": "VNCCS Emotion Core",
+      "name": "VNCCS Clothes Core",
       "hf_repo": "MIUProject/VNCCS_v3.0",
-      "hf_path": "models/loras/qwen/VNCCS/VNCCS_QIE2511_EmotionCore-RC1.safetensors",
-      "local_path": "models/loras/qwen/VNCCS/VNCCS_QIE2511_EmotionCore-RC1.safetensors",
-      "version": "0.1.0",
-      "description": "Core LoRA for generating character emotions.",
+      "hf_path": "models/loras/qwen/VNCCS/VNCCS_QIE2511_ClothesCore-RC3.6.safetensors",
+      "local_path": "models/loras/qwen/VNCCS/VNCCS_QIE2511_ClothesCore-RC3.6.safetensors",
+      "version": "0.3.6",
+      "description": "Helps maintain clothing consistency.",
+      "type": "Helper",
+      "kind": "QIE2511"
+    },
+    {
+      "name": "VNCCS Clothes Core",
+      "hf_repo": "MIUProject/VNCCS_v3.0",
+      "hf_path": "models/loras/qwen/VNCCS/VNCCS_QIE2511_ClothesCore-RC3.7.safetensors",
+      "local_path": "models/loras/qwen/VNCCS/VNCCS_QIE2511_ClothesCore-RC3.7.safetensors",
+      "version": "0.3.7",
+      "description": "Helps maintain clothing consistency.",
       "type": "Helper",
       "kind": "QIE2511"
     },

--- a/nodes/clothes_designer.py
+++ b/nodes/clothes_designer.py
@@ -307,6 +307,7 @@ class ClothesDesigner:
 
     RETURN_TYPES = ("IMAGE", "STRING", "*")
     RETURN_NAMES = ("character", "sheets_path", "background")
+    OUTPUT_NODE = True
     FUNCTION = "process"
     CATEGORY = "VNCCS"
 

--- a/nodes/vnccs_control_center.py
+++ b/nodes/vnccs_control_center.py
@@ -65,6 +65,7 @@ class _ByPassTypeTuple(tuple):
 
 
 _CC_CONFIG_CACHE = {}
+_CC_CONFIG_SYNC_LOCK = threading.Lock()
 _DOWNLOAD_STATUS = {}
 _DOWNLOAD_QUEUE = queue.Queue()
 _CUSTOM_LORAS_FILE = "vnccs_custom_loras.json"
@@ -471,6 +472,43 @@ def _uses_packaged_cc_config(repo_id):
     return repo_id in _PACKAGED_CC_REPO_IDS and os.path.exists(_get_packaged_cc_path())
 
 
+def _sync_packaged_cc_config(repo_id, data):
+    if repo_id not in _PACKAGED_CC_REPO_IDS or not isinstance(data, dict):
+        return False
+
+    target = _get_packaged_cc_path()
+    tmp_path = None
+    try:
+        with _CC_CONFIG_SYNC_LOCK:
+            current = None
+            if os.path.exists(target):
+                try:
+                    with open(target, "r", encoding="utf-8") as handle:
+                        current = json.load(handle)
+                except Exception:
+                    current = None
+            if current == data:
+                return False
+
+            os.makedirs(os.path.dirname(target), exist_ok=True)
+            tmp_path = f"{target}.tmp.{os.getpid()}.{threading.get_ident()}"
+            with open(tmp_path, "w", encoding="utf-8") as handle:
+                json.dump(data, handle, indent=2, ensure_ascii=False)
+                handle.write("\n")
+            os.replace(tmp_path, target)
+            print(f"[VNCCS Control Center] Updated packaged catalog from '{repo_id}'.")
+            return True
+    except Exception as exc:
+        print(f"[VNCCS Control Center] Failed to update packaged catalog: {exc}")
+        if tmp_path:
+            try:
+                if os.path.exists(tmp_path):
+                    os.remove(tmp_path)
+            except Exception:
+                pass
+        return False
+
+
 def _get_cc_config(repo_id, prefer_remote=False):
     cached = _CC_CONFIG_CACHE.get(repo_id)
     now = time.time()
@@ -499,6 +537,8 @@ def _get_cc_config(repo_id, prefer_remote=False):
             source = "packaged"
     with open(path, "r", encoding="utf-8") as handle:
         data = json.load(handle)
+    if source == "huggingface":
+        _sync_packaged_cc_config(repo_id, data)
     _CC_CONFIG_CACHE[repo_id] = {"ts": now, "data": data, "source": source}
     return _dedupe_config_by_name(_merge_custom_loras(data))
 

--- a/nodes/vnccs_utils.py
+++ b/nodes/vnccs_utils.py
@@ -1970,22 +1970,35 @@ class VNCCSChromaKey:
             device=_select_torch_device(),
             precision="bf16",
         )
-        result = _call_registered_node(
-            ["Sam3ImageSegmentation", "easy sam3ImageSegmentation"],
-            method_names=("segment", "segment_image", "process", "execute"),
-            sam3_model=sam3_model,
-            images=image,
-            prompt="face, clothes, accessories, hat, boots, eyes",
-            threshold=0.40,
-            keep_model_loaded=False,
-            add_background="none",
-            detection_limit=-1,
-            coordinates_positive=None,
-            coordinates_negative=None,
-            bboxes=None,
-            mask=None,
-        )
-        return _normalize_mask_batch(result, target_hw=target_hw, batch_size=int(image.shape[0]), stage="SAM3 recovery")
+        batch_size = int(image.shape[0])
+        recovery_masks = []
+        # Older Easy-SAM3 releases stack variable-length detection boxes across
+        # a batch. Segment frames individually while keeping the model loaded.
+        for index in range(batch_size):
+            result = _call_registered_node(
+                ["Sam3ImageSegmentation", "easy sam3ImageSegmentation"],
+                method_names=("segment", "segment_image", "process", "execute"),
+                sam3_model=sam3_model,
+                images=image[index:index + 1],
+                prompt="face, clothes, accessories, hat, boots, eyes",
+                threshold=0.40,
+                keep_model_loaded=index < batch_size - 1,
+                add_background="none",
+                detection_limit=-1,
+                coordinates_positive=None,
+                coordinates_negative=None,
+                bboxes=None,
+                mask=None,
+            )
+            recovery_masks.append(
+                _normalize_mask_batch(
+                    result,
+                    target_hw=target_hw,
+                    batch_size=1,
+                    stage=f"SAM3 recovery image {index + 1}/{batch_size}",
+                )
+            )
+        return torch.cat(recovery_masks, dim=0)
 
     def _restore_recovery_details(
         self,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "vnccs"
 description = "VNCCS - Visual Novel Character Creation Suite"
-version = "3.0.1"
+version = "3.0.2"
 license = {file = "LICENSE"} 
 
 dependencies = [

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -30,6 +30,7 @@ comfy_samplers.KSampler = _KSamplerStub
 # ── folder_paths ──────────────────────────────────────────────────────────────
 folder_paths = _make_stub("folder_paths")
 folder_paths.base_path = "/tmp/comfyui"
+folder_paths.models_dir = "/tmp/comfyui/models"
 folder_paths.get_output_directory = lambda: "/tmp/comfyui/output"
 folder_paths.get_filename_list = lambda _: []
 folder_paths.get_full_path = lambda *_: None

--- a/tests/test_control_center.py
+++ b/tests/test_control_center.py
@@ -1,5 +1,6 @@
 """Tests for nodes/vnccs_control_center.py — pure helper functions."""
 
+import json
 import os
 import sys
 
@@ -24,6 +25,9 @@ from nodes.vnccs_control_center import (
     _enrich_config_entries,
     _merge_custom_loras,
     _remove_custom_lora,
+    _sync_packaged_cc_config,
+    _get_cc_config,
+    _CC_CONFIG_CACHE,
     _describe_gguf_loader,
     _load_gguf,
     VNCCSPipeProxy,
@@ -323,6 +327,142 @@ class TestEnrichConfigEntries:
 
         assert result[0]["status"] == "installed"
         assert result[0]["active_version"] == "0.3.5"
+
+
+class TestPackagedConfigSync:
+    def test_updates_packaged_catalog_atomically(self, tmp_path, monkeypatch):
+        target = tmp_path / "control_center.json"
+        target.write_text('{"name": "old"}\n', encoding="utf-8")
+        monkeypatch.setattr(
+            "nodes.vnccs_control_center._get_packaged_cc_path",
+            lambda: str(target),
+        )
+
+        updated = {
+            "name": "current",
+            "lora": [
+                {
+                    "name": "VNCCS Clothes Core",
+                    "version": "0.3.7",
+                    "local_path": "models/loras/qwen/VNCCS/VNCCS_QIE2511_ClothesCore-RC3.7.safetensors",
+                }
+            ],
+        }
+
+        assert _sync_packaged_cc_config("MIUProject/VNCCS_v3.0", updated) is True
+        assert target.read_text(encoding="utf-8").endswith("\n")
+        assert json.loads(target.read_text(encoding="utf-8")) == updated
+        assert list(tmp_path.glob("control_center.json.tmp.*")) == []
+        assert _sync_packaged_cc_config("MIUProject/VNCCS_v3.0", updated) is False
+
+    def test_ignores_unrelated_repositories(self, tmp_path, monkeypatch):
+        target = tmp_path / "control_center.json"
+        monkeypatch.setattr(
+            "nodes.vnccs_control_center._get_packaged_cc_path",
+            lambda: str(target),
+        )
+
+        assert _sync_packaged_cc_config("someone/else", {"name": "remote"}) is False
+        assert not target.exists()
+
+    def test_remote_config_refreshes_packaged_fallback(self, tmp_path, monkeypatch):
+        target = tmp_path / "control_center.json"
+        remote = tmp_path / "remote_control_center.json"
+        target.write_text('{"name": "old"}\n', encoding="utf-8")
+        remote_data = {
+            "name": "current",
+            "models": [],
+            "clip": [],
+            "vae": [],
+            "lora": [],
+            "controlnet": [],
+            "other": [],
+        }
+        remote.write_text(json.dumps(remote_data), encoding="utf-8")
+
+        monkeypatch.setattr(
+            "nodes.vnccs_control_center._get_packaged_cc_path",
+            lambda: str(target),
+        )
+        monkeypatch.setattr(
+            "nodes.vnccs_control_center.hf_hub_download",
+            lambda **kwargs: str(remote),
+        )
+        monkeypatch.setattr(
+            "nodes.vnccs_control_center._load_custom_loras",
+            lambda: [],
+        )
+        _CC_CONFIG_CACHE.clear()
+
+        try:
+            loaded = _get_cc_config("MIUProject/VNCCS_v3.0", prefer_remote=True)
+        finally:
+            _CC_CONFIG_CACHE.clear()
+
+        assert loaded["name"] == "current"
+        assert json.loads(target.read_text(encoding="utf-8")) == remote_data
+
+    def test_packaged_catalog_uses_current_clothes_core(self):
+        path = os.path.join(os.path.dirname(os.path.dirname(__file__)), "control_center.json")
+        with open(path, "r", encoding="utf-8") as handle:
+            config = _dedupe_config_by_name(json.load(handle))
+
+        clothes_core = next(
+            entry for entry in config["lora"]
+            if entry["name"] == "VNCCS Clothes Core"
+        )
+
+        assert clothes_core["version"] == "0.3.7"
+        assert clothes_core["local_path"].endswith("VNCCS_QIE2511_ClothesCore-RC3.7.safetensors")
+        assert all(entry["name"] != "VNCCS Emotion Core" for entry in config["lora"])
+
+
+class TestClothesPreviewFrontendContract:
+    def test_custom_preview_uses_partial_graph_execution(self):
+        path = os.path.join(
+            os.path.dirname(os.path.dirname(__file__)),
+            "web",
+            "vnccs_clothes_designer.js",
+        )
+        with open(path, "r", encoding="utf-8") as handle:
+            source = handle.read()
+
+        assert 'controlCenter.selected_type === "custom"' in source
+        assert "app.queuePrompt(0, 1, [targetId])" in source
+        assert 'api.addEventListener("vnccs.preview.updated", onPreview)' in source
+        assert 'api.addEventListener("execution_cached", onCached)' in source
+        assert "cachedNodes.some(nodeId => String(nodeId) === targetId)" in source
+
+    def test_clothes_designer_is_partial_execution_output(self):
+        path = os.path.join(
+            os.path.dirname(os.path.dirname(__file__)),
+            "nodes",
+            "clothes_designer.py",
+        )
+        with open(path, "r", encoding="utf-8") as handle:
+            source = handle.read()
+
+        class_source = source.split("class ClothesDesigner:", 1)[1]
+        assert "OUTPUT_NODE = True" in class_source
+
+    def test_generated_preview_preserves_cache_input_signature(self):
+        path = os.path.join(
+            os.path.dirname(os.path.dirname(__file__)),
+            "web",
+            "vnccs_clothes_designer.js",
+        )
+        with open(path, "r", encoding="utf-8") as handle:
+            source = handle.read()
+
+        assert 'if (url.includes("force_cache=true")) return;' in source
+        force_cache_branch = source.split("if (forceCache) {", 1)[1].split("} else {", 1)[0]
+        assert "selected_preview_sprite = null" not in force_cache_branch
+        custom_preview_branch = source.split(
+            'if (controlCenter.selected_type === "custom") {',
+            1,
+        )[1].split("} else {", 1)[0]
+        assert "if (previewResult?.cached)" in custom_preview_branch
+        assert custom_preview_branch.count("updatePreviewImage(true)") == 1
 
 
 # ── custom LoRA helpers ──────────────────────────────────────────────────────

--- a/tests/test_vnccs_utils_nodes.py
+++ b/tests/test_vnccs_utils_nodes.py
@@ -11,10 +11,10 @@ from PIL import Image
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
 
+import nodes.vnccs_utils as vnccs_utils
 from nodes.vnccs_utils import (
     tensor2pil, pil2tensor, _ensure_float01,
     _unwrap_node_result,
-    VNCCS_QuadSplitter as _QS,  # also tested in sheet_manager; skip here
     VNCCS_ClothesTemplates,
     VNCCS_VLAnalyzer,
     _build_vl_analyzer_prompt,
@@ -102,6 +102,41 @@ def test_sam3_recovery_restores_only_shrunk_mask_area():
     assert restored_rgba[5, 5, 0].item() == pytest.approx(1.0)
     assert restored_alpha[2, 2].item() == pytest.approx(0.0)
     assert restored_rgba[2, 2, 0].item() == pytest.approx(0.0)
+
+
+def test_sam3_recovery_segments_batch_one_image_at_a_time(monkeypatch):
+    node = VNCCSChromaKey()
+    image = torch.zeros((3, 6, 8, 3), dtype=torch.float32)
+    model = object()
+    loader_calls = []
+    segment_calls = []
+
+    monkeypatch.setattr(vnccs_utils, "_ensure_sam3_model_available", lambda: "sam3.safetensors")
+
+    def fake_call(class_names, method_names=None, **kwargs):
+        if class_names[0] == "LoadSam3Model":
+            loader_calls.append(kwargs["model"])
+            return model
+
+        assert kwargs["sam3_model"] is model
+        if kwargs["images"].shape[0] != 1:
+            raise RuntimeError(
+                "stack expects each tensor to be equal size, "
+                "but got [3, 4] at entry 0 and [6, 4] at entry 2"
+            )
+        assert kwargs["images"].shape == (1, 6, 8, 3)
+        segment_calls.append(kwargs["keep_model_loaded"])
+        mask_value = len(segment_calls) / 10.0
+        return torch.full((1, 6, 8), mask_value, dtype=torch.float32)
+
+    monkeypatch.setattr(vnccs_utils, "_call_registered_node", fake_call)
+
+    masks = node._run_sam3_recovery_masks(image, target_hw=(6, 8))
+
+    assert masks.shape == (3, 6, 8)
+    assert [masks[index, 0, 0].item() for index in range(3)] == pytest.approx([0.1, 0.2, 0.3])
+    assert loader_calls == ["sam3.safetensors"]
+    assert segment_calls == [True, True, False]
 
 
 def test_connected_key_fringe_suppression_is_not_used_by_chroma_key(monkeypatch):

--- a/web/vnccs_clothes_designer.js
+++ b/web/vnccs_clothes_designer.js
@@ -960,8 +960,61 @@ app.registerExtension({
                         : JSON.stringify(stateWidget?.value ?? {});
 
                     if (!repo_id || !node_state) return null;
-                    return { repo_id, node_state };
+                    let selected_type = "";
+                    try {
+                        selected_type = String(JSON.parse(node_state)?.selected_type || "").toLowerCase();
+                    } catch {
+                        selected_type = "";
+                    }
+                    return { repo_id, node_state, selected_type };
                 };
+
+                const queueConnectedPreview = () => new Promise((resolve, reject) => {
+                    const targetId = String(node.id);
+                    let settled = false;
+                    const cleanup = () => {
+                        clearTimeout(timeout);
+                        api.removeEventListener("vnccs.preview.updated", onPreview);
+                        api.removeEventListener("execution_cached", onCached);
+                        api.removeEventListener("execution_error", onError);
+                        api.removeEventListener("execution_interrupted", onInterrupted);
+                    };
+                    const finish = (callback, value) => {
+                        if (settled) return;
+                        settled = true;
+                        cleanup();
+                        callback(value);
+                    };
+                    const onPreview = (event) => {
+                        if (String(event.detail?.node_id) === targetId) {
+                            finish(resolve, { cached: false });
+                        }
+                    };
+                    const onCached = (event) => {
+                        const cachedNodes = Array.isArray(event.detail?.nodes) ? event.detail.nodes : [];
+                        if (cachedNodes.some(nodeId => String(nodeId) === targetId)) {
+                            finish(resolve, { cached: true });
+                        }
+                    };
+                    const onError = (event) => {
+                        const detail = event.detail || {};
+                        const message = detail.exception_message || detail.error || detail.message || "Preview execution failed.";
+                        finish(reject, new Error(String(message)));
+                    };
+                    const onInterrupted = () => {
+                        finish(reject, new Error("Preview execution was interrupted."));
+                    };
+                    const timeout = setTimeout(
+                        () => finish(reject, new Error("Preview execution timed out.")),
+                        15 * 60 * 1000,
+                    );
+
+                    api.addEventListener("vnccs.preview.updated", onPreview);
+                    api.addEventListener("execution_cached", onCached);
+                    api.addEventListener("execution_error", onError);
+                    api.addEventListener("execution_interrupted", onInterrupted);
+                    Promise.resolve(app.queuePrompt(0, 1, [targetId])).catch(error => finish(reject, error));
+                });
 
                 const getConnectedControlCenterWidget = () => {
                     const input = node?.inputs?.find((item) => item.name === "pipe") ?? node?.inputs?.[0];
@@ -1545,26 +1598,35 @@ app.registerExtension({
                     `;
                     container.appendChild(loadingOverlay);
 
-                    saveCostumeToBackend();
+                    await saveCostumeToBackend();
                     saveState();
                     btnGen.innerText = "GENERATING..."; btnGen.disabled = true;
                     try {
-                        const r = await api.fetchApi("/vnccs/control_center/clothes_preview", {
-                            method: "POST",
-                            headers: { "Content-Type": "application/json" },
-                            body: JSON.stringify({
-                                ...controlCenter,
-                                clothes_state: state,
-                            })
-                        });
-                        if (r.ok) {
-                            const d = await r.json();
-                            if (d.image) {
-                                els.previewImg.src = "data:image/png;base64," + d.image;
-                                els.previewImg.style.display = "block";
-                                els.placeholder.style.display = "none";
+                        if (controlCenter.selected_type === "custom") {
+                            const previewResult = await queueConnectedPreview();
+                            if (previewResult?.cached) {
+                                await updatePreviewImage(true);
                             }
-                        } else showInfo("Error", await r.text() || "Failed");
+                        } else {
+                            const r = await api.fetchApi("/vnccs/control_center/clothes_preview", {
+                                method: "POST",
+                                headers: { "Content-Type": "application/json" },
+                                body: JSON.stringify({
+                                    ...controlCenter,
+                                    clothes_state: state,
+                                })
+                            });
+                            if (r.ok) {
+                                const d = await r.json();
+                                if (d.image) {
+                                    els.previewImg.src = "data:image/png;base64," + d.image;
+                                    els.previewImg.style.display = "block";
+                                    els.placeholder.style.display = "none";
+                                }
+                            } else {
+                                showInfo("Error", await r.text() || "Failed");
+                            }
+                        }
                     } catch (e) { showInfo("Error", e.toString()); }
                     finally {
                         loadingOverlay.remove();
@@ -1616,7 +1678,12 @@ app.registerExtension({
                     prevButton: spritePrevBtn,
                     nextButton: spriteNextBtn,
                     countLabel: spriteCount,
-                    onLoaded: (_url, previewState) => {
+                    onLoaded: (url, previewState) => {
+                        // A generated preview is only a visual fallback. Keep the
+                        // source sprite selection that was used to produce it so
+                        // the following full workflow has the same widget_data
+                        // signature and can reuse the preview cache.
+                        if (url.includes("force_cache=true")) return;
                         if (previewState.count > 0) {
                             state.selected_preview_sprite = {
                                 character: previewState.character,
@@ -1795,8 +1862,6 @@ app.registerExtension({
                     } catch (e) { console.warn("[VNCCS] ClothesDesigner: Error in preview update", e); }
 
                     if (forceCache) {
-                        state.selected_preview_sprite = null;
-                        saveState();
                         spritePreviewNavigator?.showFallback(url);
                     } else {
                         await spritePreviewNavigator?.load(state.character, {


### PR DESCRIPTION
# VNCCS 3.0.2 Changelog

This changelog describes the changes in version `3.0.2` compared with `3.0.1`.
The release focuses on Clothes Designer preview execution, Control Center catalog freshness, and SAM3 batch stability.

## Headline Changes

- Clothes Designer previews now work with the `CUSTOM` Control Center configuration by executing the connected workflow branch, so externally supplied `MODEL`, `CLIP`, and `VAE` inputs are used correctly.
- Clothes Designer is now a valid ComfyUI partial-execution target, fixing the `Prompt has no outputs` error when generating a custom preview.
- SAM3 detail recovery now processes image batches one image at a time, fixing tensor-stack failures when different images produce different numbers of detections.
- The bundled Control Center catalog has been updated to the current model list and is automatically refreshed after a newer catalog is loaded from Hugging Face.

## Clothes Designer

- `Generate Preview` in `CUSTOM` mode now queues only the graph required to execute the connected Clothes Designer node instead of calling the standalone preview endpoint.
- Custom previews now use the model stack and settings supplied through the connected Control Center pipe.
- Preview generation waits for the `vnccs.preview.updated` event before refreshing the displayed image.
- Execution errors, interruptions, and preview timeouts are now reported by the Clothes Designer UI.
- Clothes Designer is now marked as an output node so ComfyUI accepts it as the destination of partial graph execution.

## Control Center and Model Catalog

- Updated the packaged `control_center.json` to match the current remote catalog.
- A successfully downloaded Control Center catalog is now written back to the packaged fallback file, preventing an older bundled catalog from reappearing after model updates or remote access failures.
- Packaged catalog updates use a lock and atomic file replacement so concurrent reads cannot observe a partially written JSON file.
- The packaged file is left untouched when the downloaded catalog has not changed, and synchronization failures no longer prevent Control Center from using the downloaded data.

## Chroma Key and SAM3 Recovery

- SAM3 recovery segmentation now runs separately for every image in a batch.
- This avoids `torch.stack` failures in Easy SAM3 when detection-box counts or shapes differ between batch items.
- The SAM3 model is loaded once, retained between images, and released after the final image in the batch.
- Recovered masks are normalized per image and concatenated back into the original batch order.

## Reliability and Maintenance

- Added regression coverage for atomic packaged-catalog synchronization and remote catalog refresh.
- Added checks that the bundled catalog selects Clothes Core `0.3.7` and no longer exposes the obsolete Emotion Core entry.
- Added frontend contract coverage for custom partial preview execution.
- Added a regression check that Clothes Designer remains a valid output target.
- Added batch recovery coverage that reproduces the variable-detection SAM3 failure.
- Updated test environment model-path stubs for the current Control Center behavior.
- Updated package version metadata from `3.0.1` to `3.0.2`.