### PR TITLE
Fix Step 3 OOM and add pose selection

### DIFF
--- a/nodes/character_generator.py
+++ b/nodes/character_generator.py
@@ -471,7 +471,7 @@ def _view_url_for_output_path(path):
         return None
 
 
-def _tensor_to_preview_urls(image, unique_id, stage, cache_dir=None, max_items=12):
+def _tensor_to_preview_urls(image, unique_id, stage, cache_dir=None, max_items=12, start_index=0):
     image = _first_tensor(image)
     if image is None or not torch.is_tensor(image):
         return None
@@ -488,7 +488,7 @@ def _tensor_to_preview_urls(image, unique_id, stage, cache_dir=None, max_items=1
         os.makedirs(out_dir, exist_ok=True)
 
         previews = []
-        for index, item in enumerate(tensor[:max_items], start=1):
+        for index, item in enumerate(tensor[:max_items], start=int(start_index) + 1):
             array = (item.numpy() * 255).astype(np.uint8)
             mode = "RGBA" if array.shape[-1] == 4 else "RGB"
             pil = Image.fromarray(array, mode=mode)
@@ -578,7 +578,7 @@ def _save_run_inputs(cache_dir, **items):
         print(f"[VNCCS Character Generator] Failed to cache run inputs: {exc}")
 
 
-def _load_run_inputs(cache_dir):
+def _load_run_inputs(cache_dir, keys=None):
     cache_dir = _safe_cache_dir(cache_dir)
     if not cache_dir:
         return {}
@@ -589,7 +589,10 @@ def _load_run_inputs(cache_dir):
         with open(path, "r", encoding="utf-8") as handle:
             meta = json.load(handle)
         result = {}
+        requested = set(keys) if keys is not None else None
         for key, item in (meta.get("items") or {}).items():
+            if requested is not None and key not in requested:
+                continue
             if item.get("type") == "tensor":
                 value = _load_cached_tensor(cache_dir, f"input_{key}")
                 if value is not None:
@@ -780,6 +783,7 @@ DEFAULT_WIDGET_DATA = {
         "temporal_overlap": 8,
     },
     "emotion_generation": {
+        "task_batch_size": 0,
         "face_denoise": 0.55,
         "use_sam": True,
         "bbox_model": "bbox/face_yolov8m.pt",
@@ -1023,7 +1027,20 @@ class VNCCS_CharacterGenerator:
             return value[0] if value else None
         return value
 
-    def _emit(self, unique_id, stage, status, images=None, message="", current=None, total=None, cache_dir=None, lora_info=None):
+    def _emit(
+        self,
+        unique_id,
+        stage,
+        status,
+        images=None,
+        message="",
+        current=None,
+        total=None,
+        cache_dir=None,
+        lora_info=None,
+        preview_start=0,
+        append_images=False,
+    ):
         if server is None or not unique_id:
             return
         payload = {
@@ -1039,7 +1056,14 @@ class VNCCS_CharacterGenerator:
         if lora_info is not None:
             payload["lora_info"] = lora_info
         if images is not None:
-            payload["images"] = _tensor_to_preview_urls(images, unique_id, stage, cache_dir=cache_dir)
+            payload["images"] = _tensor_to_preview_urls(
+                images,
+                unique_id,
+                stage,
+                cache_dir=cache_dir,
+                start_index=preview_start,
+            )
+            payload["append_images"] = bool(append_images)
         try:
             server.PromptServer.instance.send_sync("vnccs.character_generator.stage", payload)
         except Exception as exc:
@@ -2646,6 +2670,7 @@ class VNCCS_EmotionsGenerator(VNCCS_CharacterGenerator):
 
     RETURN_TYPES = ("IMAGE", "IMAGE")
     RETURN_NAMES = ("sprites", "faces")
+    OUTPUT_IS_LIST = (True, True)
     FUNCTION = "process"
     CATEGORY = "VNCCS"
     DESCRIPTION = "Emotion sprite generator that replaces the Step 3 emotion workflow."
@@ -2679,17 +2704,168 @@ class VNCCS_EmotionsGenerator(VNCCS_CharacterGenerator):
         if not path or not os.path.exists(path):
             return None, None
         try:
-            img = Image.open(path)
-            img = ImageOps.exif_transpose(img)
-            has_alpha = img.mode == "RGBA" or img.mode == "LA" or (img.mode == "P" and "transparency" in img.info)
-            img = img.convert("RGBA")
-            arr = np.array(img).astype(np.float32) / 255.0
-            image = torch.from_numpy(arr[..., :3]).unsqueeze(0)
-            mask = torch.from_numpy(1.0 - arr[..., 3]).unsqueeze(0) if has_alpha else None
+            with Image.open(path) as opened:
+                img = ImageOps.exif_transpose(opened)
+                has_alpha = img.mode == "RGBA" or img.mode == "LA" or (img.mode == "P" and "transparency" in img.info)
+                rgb_arr = np.asarray(img.convert("RGB"), dtype=np.uint8).copy()
+                alpha_arr = np.asarray(img.convert("RGBA").getchannel("A"), dtype=np.uint8).copy() if has_alpha else None
+            image = torch.from_numpy(rgb_arr).to(dtype=torch.float32).div_(255.0).unsqueeze(0)
+            mask = (
+                1.0 - torch.from_numpy(alpha_arr).to(dtype=torch.float32).div_(255.0).unsqueeze(0)
+                if alpha_arr is not None
+                else None
+            )
             return image, mask
         except Exception as exc:
             print(f"[VNCCS Emotions Generator] Failed to load source sprite '{path}': {exc}")
             return None, None
+
+    def _source_sprite_hw(self, path, character_name=""):
+        path = _safe_existing_character_image_path(path, character_name)
+        if not path or not os.path.exists(path):
+            return None
+        try:
+            with Image.open(path) as image:
+                width, height = image.size
+            return int(height), int(width)
+        except Exception as exc:
+            print(f"[VNCCS Emotions Generator] Failed to inspect source sprite '{path}': {exc}")
+            return None
+
+    def _prepare_emotion_source(self, image, mask, target_hw):
+        image = self._safe_image_batch(image, stage="emotion source")
+        if not torch.is_tensor(image) or image.ndim != 4:
+            return None, None
+        current_hw = (int(image.shape[1]), int(image.shape[2]))
+        if target_hw and current_hw != tuple(target_hw):
+            if mask is None:
+                raise RuntimeError(
+                    "Emotion source sprites have different canvas sizes and a source has no alpha mask. "
+                    "Regenerate or remigrate the source sprites with a uniform transparent canvas."
+                )
+            image = self._pad_tensor_image(image, target_hw)
+            mask = self._pad_tensor_mask(mask, target_hw)
+            if image is None or mask is None:
+                raise RuntimeError("Failed to pad an emotion source sprite to the shared canvas.")
+        else:
+            mask = resize_mask_batch(mask, current_hw)
+        return image, mask
+
+    def _emotion_batch_plan(self, task_count, target_hw, emotion_settings):
+        gib = 1024 ** 3
+        pixels = max(1, int((target_hw or (1024, 1024))[0]) * int((target_hw or (1024, 1024))[1]))
+        requested = 0
+        try:
+            requested = max(0, int(emotion_settings.get("task_batch_size", 0) or 0))
+        except Exception:
+            requested = 0
+
+        gpu_limit = 1
+        free_vram = total_vram = 0
+        if torch.cuda.is_available():
+            try:
+                free_vram, total_vram = torch.cuda.mem_get_info()
+                reserve = max(3 * gib, int(total_vram * 0.25))
+                per_task = max(4 * gib, pixels * 4 * 24)
+                capacity_limit = max(1, int(max(0, free_vram - reserve) // per_task))
+                vram_gib = max(1, int(round(total_vram / gib)))
+                tier_limit = max(1, vram_gib // 8)
+                gpu_limit = max(1, min(capacity_limit, tier_limit, 4))
+            except Exception:
+                gpu_limit = 1
+
+        ram_limit = 4
+        available_ram = 0
+        try:
+            import psutil
+            available_ram = int(psutil.virtual_memory().available)
+            reserve_ram = min(8 * gib, max(4 * gib, int(available_ram * 0.30)))
+            per_task_ram = max(1 * gib, pixels * 4 * 16)
+            ram_limit = max(1, int(max(0, available_ram - reserve_ram) // per_task_ram))
+        except Exception:
+            ram_limit = 2
+
+        safe_limit = max(1, min(gpu_limit, ram_limit, 4, max(1, int(task_count))))
+        batch_size = min(requested, safe_limit) if requested > 0 else safe_limit
+        return {
+            "batch_size": max(1, batch_size),
+            "requested": requested,
+            "gpu_limit": gpu_limit,
+            "ram_limit": ram_limit,
+            "free_vram_gib": free_vram / gib if free_vram else 0.0,
+            "total_vram_gib": total_vram / gib if total_vram else 0.0,
+            "available_ram_gib": available_ram / gib if available_ram else 0.0,
+        }
+
+    def _emotion_preview_tensor(self, image, max_side=768):
+        batch = self._list_to_batch(image)
+        if not torch.is_tensor(batch) or batch.ndim != 4:
+            return None
+        height, width = int(batch.shape[1]), int(batch.shape[2])
+        longest = max(height, width)
+        if longest <= int(max_side):
+            return batch.detach().cpu()
+        scale = float(max_side) / float(longest)
+        target = (max(1, int(round(height * scale))), max(1, int(round(width * scale))))
+        return F.interpolate(
+            batch.detach().cpu().movedim(-1, 1).float(),
+            size=target,
+            mode="bilinear",
+            align_corners=False,
+            antialias=True,
+        ).movedim(1, -1).clamp(0.0, 1.0)
+
+    def _emotion_cache_item_key(self, stage, item_index):
+        return f"{stage}__item_{int(item_index) + 1:04d}"
+
+    def _load_emotion_cache_item(self, cache_dir, stage, item_index, target_hw=None, mask=False):
+        cached = _load_cached_tensor(cache_dir, self._emotion_cache_item_key(stage, item_index))
+        if cached is None:
+            return None
+        cached = cached.float()
+        return resize_mask_batch(cached, target_hw) if mask else self._safe_image_batch(
+            cached,
+            target_hw=target_hw,
+            stage=f"{stage} cached item",
+        )
+
+    def _save_emotion_cache_item(self, cache_dir, stage, item_index, tensor):
+        if torch.is_tensor(tensor):
+            _save_cached_tensor(
+                cache_dir,
+                self._emotion_cache_item_key(stage, item_index),
+                tensor.detach().cpu().to(dtype=torch.float16),
+            )
+
+    def _load_saved_emotion_output(self, meta, save_index):
+        if not isinstance(meta, dict):
+            return None
+        prefix = _safe_emotion_output_prefix(
+            meta.get("sprite_output_path", ""),
+            meta.get("character", ""),
+            root_name="Sprites",
+        )
+        if not prefix:
+            return None
+        path = os.path.join(
+            os.path.dirname(prefix),
+            f"{os.path.basename(prefix)}{int(save_index):04d}.png",
+        )
+        image, mask = self._load_source_sprite_from_path(path, meta.get("character", ""))
+        if image is None:
+            return None
+        if mask is None:
+            return image
+        alpha = (1.0 - mask).unsqueeze(-1).to(device=image.device, dtype=image.dtype)
+        return torch.cat([image[..., :3], alpha], dim=-1)
+
+    def _release_emotion_batch(self):
+        gc.collect()
+        if torch.cuda.is_available():
+            try:
+                torch.cuda.empty_cache()
+            except Exception:
+                pass
 
     def _source_rgb_alpha(self, image, mask=None, target_hw=None):
         batch = self._safe_image_batch(image, target_hw=target_hw, stage="emotion RGBA source")
@@ -3397,48 +3573,54 @@ class VNCCS_EmotionsGenerator(VNCCS_CharacterGenerator):
         cache_dir = _character_cache_dir_from_sheets_path("", widget_payload.get("character_name", ""), unique_id)
         _remember_generator_context(unique_id, "VNCCS_EmotionsGenerator", cache_dir, pipe)
         if regenerate_from:
-            cached_inputs = _load_run_inputs(cache_dir)
-            images = cached_inputs.get("images", images)
+            cached_inputs = _load_run_inputs(cache_dir, keys={"emotion_data"})
             emotion_data = cached_inputs.get("emotion_data", emotion_data)
         image_items = self._image_list(images)
         data_items = self._parse_emotion_data(emotion_data)
-        previous_run_inputs = _load_run_inputs(cache_dir) if not regenerate_from else {}
-        emotion_inputs_changed = previous_run_inputs.get("emotion_data") != data_items
+        previous_run_inputs = _load_run_inputs(cache_dir, keys={"emotion_data"}) if not regenerate_from else {}
+        emotion_inputs_changed = False if regenerate_from else previous_run_inputs.get("emotion_data") != data_items
         if emotion_inputs_changed:
             print(
                 "[VNCCS Emotions Generator] Pose/emotion input list changed; "
                 "ignoring prior stage cache for this run."
             )
         background_color = self._emotion_background_color(widget_payload, data_items)
-        source_items = []
-        for index, meta in enumerate(data_items):
-            source_image, source_mask = self._load_source_sprite_from_path(
-                meta.get("source_path") if isinstance(meta, dict) else "",
-                widget_payload.get("character_name", ""),
-            )
-            if source_image is None:
-                source_image = image_items[index] if index < len(image_items) else None
-                if torch.is_tensor(source_image):
-                    source_batch = self._list_to_batch(source_image)
-                    if torch.is_tensor(source_batch) and source_batch.ndim == 4 and source_batch.shape[-1] >= 4:
-                        source_mask = 1.0 - source_batch[..., 3]
-                        source_image = source_batch[..., :3]
-                    else:
-                        source_mask = None
-            if source_image is not None:
-                source_items.append((source_image, source_mask))
-        emotion_target_hw = None
-        if source_items:
-            source_items, emotion_target_hw = self._pad_alpha_sources_to_uniform_canvas(data_items, source_items)
-            normalized_sources = []
-            for source_image, source_mask in source_items:
-                source_image = self._safe_image_batch(source_image, target_hw=emotion_target_hw, stage="emotion source")
-                source_mask = resize_mask_batch(source_mask, emotion_target_hw)
-                normalized_sources.append((source_image, source_mask))
-            source_items = normalized_sources
         emotion_items = [str(item.get("emotion_prompt", "")) for item in data_items]
         sprite_paths = [str(item.get("sprite_output_path", "")) for item in data_items]
-        total = min(len(source_items), len(data_items))
+        total = len(data_items)
+        if total <= 0:
+            raise RuntimeError("No emotion tasks to generate. Select at least one costume, pose, and emotion.")
+
+        source_shapes = []
+        character_name = str(widget_payload.get("character_name", "") or "").strip()
+        if not character_name:
+            character_name = next(
+                (
+                    str(item.get("character", "") or "").strip()
+                    for item in data_items
+                    if isinstance(item, dict) and str(item.get("character", "") or "").strip()
+                ),
+                "",
+            )
+        for index, meta in enumerate(data_items):
+            task_character = meta.get("character", character_name) if isinstance(meta, dict) else character_name
+            shape = self._source_sprite_hw(
+                meta.get("source_path") if isinstance(meta, dict) else "",
+                task_character,
+            )
+            if shape is None and index < len(image_items):
+                fallback = self._list_to_batch(image_items[index])
+                if torch.is_tensor(fallback) and fallback.ndim == 4:
+                    shape = (int(fallback.shape[1]), int(fallback.shape[2]))
+            if shape is not None:
+                source_shapes.append(shape)
+        if not source_shapes:
+            raise RuntimeError("No readable source pose images were found for the selected emotion tasks.")
+        emotion_target_hw = (
+            max(shape[0] for shape in source_shapes),
+            max(shape[1] for shape in source_shapes),
+        )
+
         groups = []
         for index in range(total):
             key = sprite_paths[index] if index < len(sprite_paths) and sprite_paths[index] else emotion_items[index]
@@ -3453,211 +3635,235 @@ class VNCCS_EmotionsGenerator(VNCCS_CharacterGenerator):
             _rotate_preview_cache(cache_dir)
         _save_run_inputs(
             cache_dir,
-            images=self._list_to_batch(images),
             emotion_data=data_items,
             widget_payload=widget_payload,
         )
 
+        unique_poses = {
+            (
+                str(item.get("costume", "") or ""),
+                str(item.get("source_path", "") or ""),
+            )
+            for item in data_items
+            if isinstance(item, dict)
+        }
+        batch_plan = self._emotion_batch_plan(total, emotion_target_hw, emotion_settings)
+        batch_size = int(batch_plan["batch_size"])
+        plan_message = (
+            f"{total} task(s) queued from {len(unique_poses)} selected pose source(s) "
+            f"across {len(groups)} selected emotion/costume pair(s); "
+            f"task batch {batch_size}, GPU limit {batch_plan['gpu_limit']}, RAM limit {batch_plan['ram_limit']}"
+        )
+        if batch_plan["total_vram_gib"]:
+            plan_message += (
+                f", VRAM {batch_plan['free_vram_gib']:.1f}/{batch_plan['total_vram_gib']:.1f} GiB free"
+            )
+        if batch_plan["requested"] > batch_size:
+            plan_message += f"; requested {batch_plan['requested']} was capped for safety"
+        print(f"[VNCCS Emotions Generator] {plan_message}", flush=True)
+
         results = []
         faces = []
         rotated_face_dirs = set()
+        completed_tasks = 0
         try:
             for group_index, group in enumerate(groups):
                 stage_key, stage_label = stage_labels[group_index]
                 bg_stage_key = f"{stage_key}_bg_remove"
                 detailer_mask_cache_key = f"{stage_key}_detailer_mask"
-                cached_raw = None
-                cached_detailer_masks = None
-                if not emotion_inputs_changed and not self._should_regenerate_stage(order, regenerate_from, stage_key):
-                    cached_raw = self._load_cached_stage(cache_dir, stage_key, unique_id, f"Using cached {stage_label}")
-                    if cached_raw is not None and not self._should_regenerate_stage(order, regenerate_from, bg_stage_key):
-                        cached_final = self._load_cached_stage(cache_dir, bg_stage_key, unique_id, f"Using cached {stage_label} BG")
-                        if cached_final is not None:
-                            results.append(cached_final)
-                            faces.append(cached_final)
-                            continue
-                    if cached_raw is not None:
-                        cached_detailer_masks = _load_cached_tensor(cache_dir, detailer_mask_cache_key)
-                        cached_detailer_masks = resize_mask_batch(cached_detailer_masks, emotion_target_hw)
-                        cached_count = int(cached_raw.shape[0]) if torch.is_tensor(cached_raw) and cached_raw.ndim == 4 else 0
-                        mask_count = (
-                            int(cached_detailer_masks.shape[0])
-                            if torch.is_tensor(cached_detailer_masks) and cached_detailer_masks.ndim == 3
-                            else 0
-                        )
-                        if cached_detailer_masks is None or mask_count != cached_count:
-                            print(
-                                f"[VNCCS Emotions Generator] Cached {stage_label} has no matching detailer mask; "
-                                "regenerating it for region-safe background removal."
-                            )
-                            cached_raw = None
-
-                group_source = self._safe_image_batch(
-                    [source_items[i][0] for i in group["indices"]],
-                    target_hw=emotion_target_hw,
-                    stage=f"{stage_key} source",
-                )
-                run_indices = group["indices"]
+                regenerate_raw = emotion_inputs_changed or self._should_regenerate_stage(order, regenerate_from, stage_key)
+                regenerate_bg = emotion_inputs_changed or self._should_regenerate_stage(order, regenerate_from, bg_stage_key)
+                run_positions = list(range(len(group["indices"])))
                 if regenerate_index is not None and regenerate_index < len(group["indices"]):
-                    run_indices = [group["indices"][regenerate_index]]
-                    group_source = source_items[run_indices[0]][0]
-                group_results = []
-                generated_items = []
-                if cached_raw is not None:
-                    raw_items = self._split_batch(cached_raw)
-                    raw_results = cached_raw
-                    selected_detailer_masks = cached_detailer_masks
-                    if regenerate_index is not None and regenerate_index < len(raw_items):
-                        raw_results = self._safe_image_batch(
-                            [raw_items[regenerate_index]],
-                            target_hw=emotion_target_hw,
-                            stage=f"{stage_key} raw regenerate slice",
-                        )
-                        selected_detailer_masks = cached_detailer_masks[
-                            regenerate_index:regenerate_index + 1
-                        ]
-                    for local_index, index in enumerate(run_indices, start=1):
-                        source_item_index = regenerate_index if regenerate_index is not None else local_index - 1
-                        fallback = raw_items[source_item_index] if source_item_index < len(raw_items) else raw_results
-                        generated_items.append({
-                            "index": index,
-                            "local_index": local_index,
-                            "result": fallback,
-                            "face_crop": fallback,
-                            "detailer_mask": selected_detailer_masks[
-                                local_index - 1:local_index
-                            ],
-                        })
-                else:
-                    self._emit(unique_id, stage_key, "running", group_source, f"Generating {stage_label}", 0, len(run_indices), cache_dir=cache_dir)
-                    for local_index, index in enumerate(run_indices, start=1):
-                        image, mask = source_items[index]
+                    run_positions = [regenerate_index]
+                group_total = len(run_positions)
+                batch_total = max(1, (group_total + batch_size - 1) // batch_size)
+                self._emit(
+                    unique_id,
+                    stage_key,
+                    "running",
+                    message=f"{plan_message}. Starting {stage_label}",
+                    current=0,
+                    total=group_total,
+                    cache_dir=cache_dir,
+                )
+
+                for batch_number, batch_start in enumerate(range(0, group_total, batch_size), start=1):
+                    batch_positions = run_positions[batch_start:batch_start + batch_size]
+                    records = []
+                    for group_position in batch_positions:
+                        index = group["indices"][group_position]
                         meta = data_items[index] if index < len(data_items) else {}
-                        if mask is not None and (mask.shape[-2] != image.shape[1] or mask.shape[-1] != image.shape[2]):
-                            mask_img = Image.fromarray((mask[0].detach().cpu().numpy() * 255).astype(np.uint8))
-                            mask_img = mask_img.resize((image.shape[2], image.shape[1]), Image.Resampling.LANCZOS)
-                            mask = torch.from_numpy(np.array(mask_img).astype(np.float32) / 255.0).unsqueeze(0)
-                        seed = int(meta.get("seed", 0) or 0)
-                        detailer_input = self._prepare_emotion_detailer_input(
-                            image,
-                            mask,
-                            background_color,
+                        task_character = meta.get("character", character_name) if isinstance(meta, dict) else character_name
+                        source_image, source_mask = self._load_source_sprite_from_path(
+                            meta.get("source_path") if isinstance(meta, dict) else "",
+                            task_character,
                         )
-                        result, face_crop, detailer_mask = self._run_emotion_generation_one(
-                            detailer_input,
-                            mask,
-                            pipe,
-                            meta.get("emotion_prompt", emotion_items[index]),
-                            self._emotion_face_details(meta),
-                            meta.get("negative_prompt", ""),
-                            seed + index,
-                            bbox_threshold=bbox_threshold,
-                            bbox_dilation=bbox_dilation,
-                            sam_dilation=sam_dilation,
-                            sam_threshold=sam_threshold,
-                            sam_bbox_expansion=sam_bbox_expansion,
-                            use_sam=use_sam,
-                            detailer_settings=emotion_settings,
-                        )
-                        raw_partial = self._safe_image_batch(
-                            [item["result"] for item in generated_items] + [result],
-                            target_hw=emotion_target_hw,
-                            stage=f"{stage_key} raw partial",
-                        )
-                        stage_status = "running" if local_index < len(run_indices) else "done"
-                        self._emit(
-                            unique_id,
-                            stage_key,
-                            stage_status,
-                            raw_partial,
-                            f"Generated {local_index}/{len(run_indices)} {stage_label}",
-                            local_index,
-                            len(run_indices),
-                            cache_dir=cache_dir,
-                        )
-                        generated_items.append({
-                            "index": index,
-                            "local_index": local_index,
-                            "result": result,
-                            "face_crop": face_crop,
-                            "detailer_mask": detailer_mask,
-                        })
-                    raw_results = self._safe_image_batch(
-                        [item["result"] for item in generated_items],
-                        target_hw=emotion_target_hw,
-                        stage=f"{stage_key} raw",
-                    )
-                    raw_cache = raw_results
-                    detailer_mask_cache = torch.cat(
-                        [
-                            resize_mask_batch(item["detailer_mask"], emotion_target_hw)
-                            for item in generated_items
-                        ],
-                        dim=0,
-                    )
-                    if regenerate_index is not None:
-                        raw_cache = self._replace_batch_item(_load_cached_tensor(cache_dir, stage_key), regenerate_index, raw_results)
-                        detailer_mask_cache = self._replace_mask_batch_item(
-                            _load_cached_tensor(cache_dir, detailer_mask_cache_key),
-                            regenerate_index,
-                            detailer_mask_cache,
+                        if source_image is None and index < len(image_items):
+                            source_image = self._list_to_batch(image_items[index])
+                            if torch.is_tensor(source_image) and source_image.ndim == 4 and source_image.shape[-1] >= 4:
+                                source_mask = 1.0 - source_image[..., 3]
+                                source_image = source_image[..., :3]
+                        source_image, source_mask = self._prepare_emotion_source(
+                            source_image,
+                            source_mask,
                             emotion_target_hw,
                         )
-                    self._save_stage(cache_dir, stage_key, raw_cache)
-                    _save_cached_tensor(cache_dir, detailer_mask_cache_key, detailer_mask_cache)
-                if raw_results is not None:
-                    bg_total = raw_results.shape[0] if torch.is_tensor(raw_results) and raw_results.ndim == 4 else len(generated_items)
-                    bg_disabled = self._bg_remove_disabled(bg_settings)
-                    bg_action = "Skipping chroma key for" if bg_disabled else "Removing background for"
+                        if source_image is None:
+                            raise RuntimeError(f"Failed to load selected pose {group_position + 1} for {stage_label}.")
+
+                        raw_result = None
+                        face_crop = None
+                        detailer_mask = None
+                        if not regenerate_raw:
+                            raw_result = self._load_emotion_cache_item(
+                                cache_dir,
+                                stage_key,
+                                group_position,
+                                target_hw=emotion_target_hw,
+                            )
+                            detailer_mask = self._load_emotion_cache_item(
+                                cache_dir,
+                                detailer_mask_cache_key,
+                                group_position,
+                                target_hw=emotion_target_hw,
+                                mask=True,
+                            )
+                            face_crop = raw_result
+
+                        if raw_result is None or detailer_mask is None:
+                            seed = int(meta.get("seed", 0) or 0)
+                            detailer_input = self._prepare_emotion_detailer_input(
+                                source_image,
+                                source_mask,
+                                background_color,
+                            )
+                            raw_result, face_crop, detailer_mask = self._run_emotion_generation_one(
+                                detailer_input,
+                                source_mask,
+                                pipe,
+                                meta.get("emotion_prompt", emotion_items[index]),
+                                self._emotion_face_details(meta),
+                                meta.get("negative_prompt", ""),
+                                seed + index,
+                                bbox_threshold=bbox_threshold,
+                                bbox_dilation=bbox_dilation,
+                                sam_dilation=sam_dilation,
+                                sam_threshold=sam_threshold,
+                                sam_bbox_expansion=sam_bbox_expansion,
+                                use_sam=use_sam,
+                                detailer_settings=emotion_settings,
+                            )
+                            self._save_emotion_cache_item(cache_dir, stage_key, group_position, raw_result)
+                            self._save_emotion_cache_item(
+                                cache_dir,
+                                detailer_mask_cache_key,
+                                group_position,
+                                resize_mask_batch(detailer_mask, emotion_target_hw),
+                            )
+
+                        try:
+                            save_index = int(meta.get("sprite_index", group_position + 1) or group_position + 1)
+                        except (TypeError, ValueError):
+                            save_index = group_position + 1
+                        records.append({
+                            "index": index,
+                            "group_position": group_position,
+                            "meta": meta,
+                            "save_index": save_index,
+                            "source_image": source_image,
+                            "source_mask": source_mask,
+                            "raw_result": raw_result,
+                            "face_crop": face_crop if face_crop is not None else raw_result,
+                            "detailer_mask": resize_mask_batch(detailer_mask, emotion_target_hw),
+                            "final": None,
+                            "generated_final": False,
+                        })
+
+                    raw_previews = [
+                        self._emotion_preview_tensor(record["raw_result"])
+                        for record in records
+                    ]
+                    raw_preview_batch = self._safe_image_batch(
+                        raw_previews,
+                        stage=f"{stage_key} preview batch",
+                    )
+                    group_done = min(group_total, batch_start + len(records))
                     self._emit(
                         unique_id,
-                        bg_stage_key,
+                        stage_key,
                         "running",
-                        raw_results,
-                        f"{bg_action} {bg_total} {stage_label} image(s)",
-                        0,
-                        bg_total,
-                        cache_dir=cache_dir,
-                    )
-                    cleaned_results = self._run_emotion_bg_remove(
-                        raw_results,
-                        [source_items[item["index"]] for item in generated_items],
-                        torch.cat(
-                            [
-                                resize_mask_batch(item["detailer_mask"], emotion_target_hw)
-                                for item in generated_items
-                            ],
-                            dim=0,
+                        raw_preview_batch,
+                        (
+                            f"Batch {batch_number}/{batch_total}: generated {group_done}/{group_total} {stage_label}; "
+                            f"overall {completed_tasks}/{total} complete"
                         ),
-                        bg_settings,
-                        background=background_color,
-                        unique_id=unique_id,
+                        group_done,
+                        group_total,
                         cache_dir=cache_dir,
-                        stage=bg_stage_key,
-                        emotion_settings=emotion_settings,
+                        preview_start=batch_positions[0] if batch_positions else batch_start,
+                        append_images=batch_number > 1,
                     )
-                    cleaned_items = self._split_batch(cleaned_results)
-                    for item_index, item in enumerate(generated_items):
-                        result = cleaned_items[item_index] if item_index < len(cleaned_items) else item["result"]
-                        index = item["index"]
-                        results.append(result)
-                        # FaceDetailer crops are intentionally variable-size. Save them
-                        # as files, but keep the IMAGE output batch shape-stable.
-                        faces.append(result)
-                        group_results.append(result)
-                        save_index = (regenerate_index + 1) if regenerate_index is not None else item["local_index"]
-                        if index < len(sprite_paths):
-                            self._save_rgba_image(
-                                result,
-                                None,
-                                sprite_paths[index],
-                                save_index,
-                                widget_payload.get("character_name", ""),
+                    bg_records = []
+                    if not regenerate_bg:
+                        for record in records:
+                            record["final"] = self._load_saved_emotion_output(
+                                record["meta"],
+                                record["save_index"],
                             )
-                            face_prefix = self._face_prefix_from_sprite_prefix(sprite_paths[index])
+                            if record["final"] is None:
+                                bg_records.append(record)
+                    else:
+                        bg_records = list(records)
+
+                    if bg_records:
+                        raw_batch = self._safe_image_batch(
+                            [record["raw_result"] for record in bg_records],
+                            target_hw=emotion_target_hw,
+                            stage=f"{bg_stage_key} raw batch",
+                        )
+                        detailer_masks = torch.cat(
+                            [record["detailer_mask"] for record in bg_records],
+                            dim=0,
+                        )
+                        cleaned = self._run_emotion_bg_remove(
+                            raw_batch,
+                            [
+                                (record["source_image"], record["source_mask"])
+                                for record in bg_records
+                            ],
+                            detailer_masks,
+                            bg_settings,
+                            background=background_color,
+                            unique_id=unique_id,
+                            cache_dir=cache_dir,
+                            stage=bg_stage_key,
+                            emotion_settings=emotion_settings,
+                        )
+                        cleaned_items = self._split_batch(cleaned)
+                        for cleaned_index, record in enumerate(bg_records):
+                            record["final"] = (
+                                cleaned_items[cleaned_index]
+                                if cleaned_index < len(cleaned_items)
+                                else record["raw_result"]
+                            )
+                            record["generated_final"] = True
+
+                    final_previews = []
+                    for record in records:
+                        final_result = record["final"] if record["final"] is not None else record["raw_result"]
+                        if record["generated_final"]:
+                            self._save_rgba_image(
+                                final_result,
+                                None,
+                                sprite_paths[record["index"]],
+                                record["save_index"],
+                                character_name,
+                            )
+                            face_prefix = self._face_prefix_from_sprite_prefix(sprite_paths[record["index"]])
                             face_prefix = _safe_emotion_output_prefix(
                                 face_prefix,
-                                widget_payload.get("character_name", ""),
+                                character_name,
                                 root_name="Faces",
                             )
                             if face_prefix:
@@ -3667,28 +3873,88 @@ class VNCCS_EmotionsGenerator(VNCCS_CharacterGenerator):
                                     self._rotate_existing_images(face_dir)
                                     rotated_face_dirs.add(face_dir_key)
                                 self._save_rgba_image(
-                                    item["face_crop"],
+                                    record["face_crop"],
                                     None,
                                     face_prefix,
-                                    save_index,
-                                    widget_payload.get("character_name", ""),
+                                    record["save_index"],
+                                    character_name,
                                     root_name="Faces",
                                 )
-                if group_results:
-                    merged = self._safe_image_batch(group_results, target_hw=emotion_target_hw, stage=f"{stage_key} merge")
-                    if regenerate_index is not None:
-                        merged = self._replace_batch_item(_load_cached_tensor(cache_dir, bg_stage_key), regenerate_index, merged)
-                    self._save_stage(cache_dir, bg_stage_key, merged)
-                    done_total = merged.shape[0] if torch.is_tensor(merged) and merged.ndim == 4 else len(run_indices)
-                    bg_done = "Chroma key skipped for" if self._bg_remove_disabled(bg_settings) else "Background removed from"
-                    self._emit(unique_id, bg_stage_key, "done", merged, f"{bg_done} {done_total} {stage_label} image(s)", done_total, done_total, cache_dir=cache_dir)
+                        preview = self._emotion_preview_tensor(final_result)
+                        if preview is not None:
+                            final_previews.append(preview)
+                            results.append(preview)
+
+                    completed_tasks += len(records)
+                    final_preview_batch = self._safe_image_batch(
+                        final_previews,
+                        stage=f"{bg_stage_key} preview batch",
+                    )
+                    bg_disabled = self._bg_remove_disabled(bg_settings)
+                    bg_action = "Chroma key skipped" if bg_disabled else "Background removed"
+                    self._emit(
+                        unique_id,
+                        bg_stage_key,
+                        "running",
+                        final_preview_batch,
+                        (
+                            f"Batch {batch_number}/{batch_total}: {bg_action.lower()} for "
+                            f"{group_done}/{group_total} {stage_label}; overall {completed_tasks}/{total} complete"
+                        ),
+                        group_done,
+                        group_total,
+                        cache_dir=cache_dir,
+                        preview_start=batch_positions[0] if batch_positions else batch_start,
+                        append_images=batch_number > 1,
+                    )
+
+                    records.clear()
+                    raw_previews.clear()
+                    final_previews.clear()
+                    bg_records.clear()
+                    raw_preview_batch = None
+                    final_preview_batch = None
+                    raw_batch = None
+                    detailer_masks = None
+                    cleaned = None
+                    cleaned_items = None
+                    source_image = None
+                    source_mask = None
+                    raw_result = None
+                    face_crop = None
+                    detailer_mask = None
+                    detailer_input = None
+                    final_result = None
+                    preview = None
+                    record = None
+                    self._release_emotion_batch()
+
+                self._emit(
+                    unique_id,
+                    stage_key,
+                    "done",
+                    message=f"Finished {group_total} {stage_label} raw image(s) in {batch_total} batch(es)",
+                    current=group_total,
+                    total=group_total,
+                    cache_dir=cache_dir,
+                )
+                bg_done = "Chroma key skipped" if self._bg_remove_disabled(bg_settings) else "Background removed"
+                self._emit(
+                    unique_id,
+                    bg_stage_key,
+                    "done",
+                    message=f"{bg_done} for {group_total} {stage_label} image(s)",
+                    current=group_total,
+                    total=group_total,
+                    cache_dir=cache_dir,
+                )
 
             if not results:
                 raise RuntimeError("No emotion images to generate. Select at least one costume and one emotion.")
-            return (
-                self._safe_image_batch(results, target_hw=emotion_target_hw, stage="emotion results"),
-                self._safe_image_batch(faces, target_hw=emotion_target_hw, stage="emotion faces"),
-            )
+            # Full-resolution sprites and variable-size face crops are saved as
+            # individual PNG files during each batch. Return independent display
+            # previews so ComfyUI does not retain every 2656x6336 float tensor.
+            return (results, results)
         except Exception as exc:
             print("[VNCCS Emotions Generator] Failed:", exc)
             traceback.print_exc()

--- a/nodes/character_generator.py
+++ b/nodes/character_generator.py
@@ -3402,6 +3402,13 @@ class VNCCS_EmotionsGenerator(VNCCS_CharacterGenerator):
             emotion_data = cached_inputs.get("emotion_data", emotion_data)
         image_items = self._image_list(images)
         data_items = self._parse_emotion_data(emotion_data)
+        previous_run_inputs = _load_run_inputs(cache_dir) if not regenerate_from else {}
+        emotion_inputs_changed = previous_run_inputs.get("emotion_data") != data_items
+        if emotion_inputs_changed:
+            print(
+                "[VNCCS Emotions Generator] Pose/emotion input list changed; "
+                "ignoring prior stage cache for this run."
+            )
         background_color = self._emotion_background_color(widget_payload, data_items)
         source_items = []
         for index, meta in enumerate(data_items):
@@ -3461,7 +3468,7 @@ class VNCCS_EmotionsGenerator(VNCCS_CharacterGenerator):
                 detailer_mask_cache_key = f"{stage_key}_detailer_mask"
                 cached_raw = None
                 cached_detailer_masks = None
-                if not self._should_regenerate_stage(order, regenerate_from, stage_key):
+                if not emotion_inputs_changed and not self._should_regenerate_stage(order, regenerate_from, stage_key):
                     cached_raw = self._load_cached_stage(cache_dir, stage_key, unique_id, f"Using cached {stage_label}")
                     if cached_raw is not None and not self._should_regenerate_stage(order, regenerate_from, bg_stage_key):
                         cached_final = self._load_cached_stage(cache_dir, bg_stage_key, unique_id, f"Using cached {stage_label} BG")

--- a/nodes/character_generator.py
+++ b/nodes/character_generator.py
@@ -558,6 +558,18 @@ def _load_cached_tensor(cache_dir, key):
         return None
 
 
+def _remove_cached_tensor(cache_dir, key):
+    path = _cache_tensor_path(cache_dir, key)
+    if not path or not os.path.isfile(path):
+        return False
+    try:
+        os.remove(path)
+        return True
+    except Exception as exc:
+        print(f"[VNCCS Character Generator] Failed to remove cached tensor '{key}': {exc}")
+        return False
+
+
 def _save_run_inputs(cache_dir, **items):
     cache_dir = _safe_cache_dir(cache_dir)
     if not cache_dir:
@@ -2665,6 +2677,8 @@ class VNCCS_EmotionsGenerator(VNCCS_CharacterGenerator):
             },
             "hidden": {
                 "unique_id": "UNIQUE_ID",
+                "prompt": "PROMPT",
+                "extra_pnginfo": "EXTRA_PNGINFO",
             },
         }
 
@@ -2681,6 +2695,76 @@ class VNCCS_EmotionsGenerator(VNCCS_CharacterGenerator):
         if isinstance(value, list):
             return value
         return [value]
+
+    def _emotion_output_connections(self, prompt, extra_pnginfo, unique_id):
+        """Return connected state for sprites/faces without retaining unused outputs."""
+        node_id = str(unique_id or "").strip()
+        connected = [False, False]
+        known = False
+
+        workflow = extra_pnginfo.get("workflow") if isinstance(extra_pnginfo, dict) else None
+        if isinstance(workflow, dict):
+            for node in workflow.get("nodes") or []:
+                if not isinstance(node, dict) or str(node.get("id")) != node_id:
+                    continue
+                known = True
+                outputs = node.get("outputs") or []
+                for output_index in range(min(2, len(outputs))):
+                    output = outputs[output_index]
+                    if isinstance(output, dict) and output.get("links"):
+                        connected[output_index] = True
+                break
+
+        if isinstance(prompt, dict):
+            known = True
+
+            def inspect_link(value):
+                if isinstance(value, dict):
+                    for nested in value.values():
+                        inspect_link(nested)
+                    return
+                if not isinstance(value, (list, tuple)):
+                    return
+                if len(value) == 2 and str(value[0]) == node_id:
+                    try:
+                        output_index = int(value[1])
+                    except (TypeError, ValueError):
+                        output_index = -1
+                    if output_index in (0, 1):
+                        connected[output_index] = True
+                        return
+                for nested in value:
+                    inspect_link(nested)
+
+            for node in prompt.values():
+                if isinstance(node, dict):
+                    inspect_link(node.get("inputs") or {})
+
+        return connected, known
+
+    def _cleanup_emotion_tensor_cache(self, cache_dir, remove_per_item=False):
+        """Remove legacy combined caches and obsolete per-item caches."""
+        removed = int(_remove_cached_tensor(cache_dir, "input_images"))
+        cache_dir = _safe_cache_dir(cache_dir)
+        stage_dir = os.path.join(cache_dir, "_stage_cache") if cache_dir else ""
+        if not stage_dir or not os.path.isdir(stage_dir):
+            return removed
+        try:
+            for filename in os.listdir(stage_dir):
+                if not filename.startswith("emotion_") or not filename.endswith(".pt"):
+                    continue
+                is_per_item = "__item_" in filename
+                if is_per_item and not remove_per_item:
+                    continue
+                path = os.path.join(stage_dir, filename)
+                if os.path.isfile(path):
+                    os.remove(path)
+                    removed += 1
+        except Exception as exc:
+            print(f"[VNCCS Emotions Generator] Failed to clean obsolete tensor cache: {exc}")
+        if removed:
+            print(f"[VNCCS Emotions Generator] Removed {removed} obsolete cached tensor file(s).")
+        return removed
 
     def _mask_from_source_path(self, path, character_name=""):
         path = _safe_existing_character_image_path(path, character_name)
@@ -2725,7 +2809,8 @@ class VNCCS_EmotionsGenerator(VNCCS_CharacterGenerator):
         if not path or not os.path.exists(path):
             return None
         try:
-            with Image.open(path) as image:
+            with Image.open(path) as opened:
+                image = ImageOps.exif_transpose(opened)
                 width, height = image.size
             return int(height), int(width)
         except Exception as exc:
@@ -2783,7 +2868,7 @@ class VNCCS_EmotionsGenerator(VNCCS_CharacterGenerator):
             per_task_ram = max(1 * gib, pixels * 4 * 16)
             ram_limit = max(1, int(max(0, available_ram - reserve_ram) // per_task_ram))
         except Exception:
-            ram_limit = 2
+            ram_limit = 1
 
         safe_limit = max(1, min(gpu_limit, ram_limit, 4, max(1, int(task_count))))
         batch_size = min(requested, safe_limit) if requested > 0 else safe_limit
@@ -3393,20 +3478,22 @@ class VNCCS_EmotionsGenerator(VNCCS_CharacterGenerator):
         filename = f"{os.path.basename(prefix)}{index:04d}.png"
         path = os.path.join(directory, filename)
 
-        rgb = image.detach().cpu().clamp(0, 1)
+        rgb = image.detach().to(device="cpu", dtype=torch.float32, copy=True)
         if rgb.ndim == 4:
             rgb = rgb[0]
-        rgb_arr = (rgb.numpy() * 255).astype(np.uint8)
+        rgb.clamp_(0.0, 1.0).mul_(255.0).round_()
+        rgb_arr = rgb.to(dtype=torch.uint8).numpy()
 
         if mask is None and rgb_arr.shape[-1] >= 4:
             alpha = rgb_arr[..., 3]
         elif mask is None:
             alpha = np.full(rgb_arr.shape[:2], 255, dtype=np.uint8)
         else:
-            m = mask.detach().cpu().clamp(0, 1)
+            m = mask.detach().to(device="cpu", dtype=torch.float32, copy=True)
             if m.ndim == 3:
                 m = m[0]
-            alpha = ((1.0 - m.numpy()) * 255).astype(np.uint8)
+            m.clamp_(0.0, 1.0).mul_(-255.0).add_(255.0).round_()
+            alpha = m.to(dtype=torch.uint8).numpy()
             if alpha.shape != rgb_arr.shape[:2]:
                 alpha = np.array(Image.fromarray(alpha).resize((rgb_arr.shape[1], rgb_arr.shape[0]), Image.Resampling.LANCZOS))
 
@@ -3528,7 +3615,16 @@ class VNCCS_EmotionsGenerator(VNCCS_CharacterGenerator):
         detailer_mask = self._detailer_mask_from_result(detailed, image, full_image)
         return full_image, face_crop, detailer_mask
 
-    def process(self, images, pipe, emotion_data, widget_data="{}", unique_id=None):
+    def process(
+        self,
+        images,
+        pipe,
+        emotion_data,
+        widget_data="{}",
+        unique_id=None,
+        prompt=None,
+        extra_pnginfo=None,
+    ):
         widget_payload = self._widget_data(widget_data)
         regenerate_from = self._regenerate_from(widget_payload)
         regenerate_index = self._regenerate_index(widget_payload)
@@ -3570,8 +3666,24 @@ class VNCCS_EmotionsGenerator(VNCCS_CharacterGenerator):
         }
         pipe = self._unwrap_scalar(pipe)
         unique_id = self._unwrap_scalar(unique_id)
+        prompt = self._unwrap_scalar(prompt)
+        extra_pnginfo = self._unwrap_scalar(extra_pnginfo)
         cache_dir = _character_cache_dir_from_sheets_path("", widget_payload.get("character_name", ""), unique_id)
+        output_connections, connections_known = self._emotion_output_connections(
+            prompt,
+            extra_pnginfo,
+            unique_id,
+        )
+        previous_context = _LIVE_GENERATOR_CONTEXTS.get(str(unique_id or "").strip()) or {}
+        if not connections_known:
+            previous_connections = previous_context.get("emotion_output_connections")
+            if isinstance(previous_connections, (list, tuple)) and len(previous_connections) >= 2:
+                output_connections = [bool(previous_connections[0]), bool(previous_connections[1])]
         _remember_generator_context(unique_id, "VNCCS_EmotionsGenerator", cache_dir, pipe)
+        live_context = _LIVE_GENERATOR_CONTEXTS.get(str(unique_id or "").strip())
+        if isinstance(live_context, dict):
+            live_context["emotion_output_connections"] = list(output_connections)
+        collect_sprites, collect_faces = output_connections
         if regenerate_from:
             cached_inputs = _load_run_inputs(cache_dir, keys={"emotion_data"})
             emotion_data = cached_inputs.get("emotion_data", emotion_data)
@@ -3584,6 +3696,7 @@ class VNCCS_EmotionsGenerator(VNCCS_CharacterGenerator):
                 "[VNCCS Emotions Generator] Pose/emotion input list changed; "
                 "ignoring prior stage cache for this run."
             )
+        self._cleanup_emotion_tensor_cache(cache_dir, remove_per_item=not regenerate_from)
         background_color = self._emotion_background_color(widget_payload, data_items)
         emotion_items = [str(item.get("emotion_prompt", "")) for item in data_items]
         sprite_paths = [str(item.get("sprite_output_path", "")) for item in data_items]
@@ -3660,11 +3773,13 @@ class VNCCS_EmotionsGenerator(VNCCS_CharacterGenerator):
             )
         if batch_plan["requested"] > batch_size:
             plan_message += f"; requested {batch_plan['requested']} was capped for safety"
+        if collect_sprites or collect_faces:
+            plan_message += "; connected IMAGE outputs will retain full-resolution tensors"
         print(f"[VNCCS Emotions Generator] {plan_message}", flush=True)
 
         results = []
         faces = []
-        rotated_face_dirs = set()
+        face_version_dirs = {}
         completed_tasks = 0
         try:
             for group_index, group in enumerate(groups):
@@ -3869,9 +3984,17 @@ class VNCCS_EmotionsGenerator(VNCCS_CharacterGenerator):
                             if face_prefix:
                                 face_dir = os.path.dirname(face_prefix)
                                 face_dir_key = os.path.normcase(os.path.abspath(face_dir))
-                                if not regenerate_from and face_dir_key not in rotated_face_dirs:
-                                    self._rotate_existing_images(face_dir)
-                                    rotated_face_dirs.add(face_dir_key)
+                                face_filename = (
+                                    f"{os.path.basename(face_prefix)}{int(record['save_index']):04d}.png"
+                                )
+                                existing_face = os.path.join(face_dir, face_filename)
+                                if not regenerate_from and os.path.isfile(existing_face):
+                                    version_dir = face_version_dirs.get(face_dir_key)
+                                    if not version_dir:
+                                        version_dir = self._version_dir(face_dir)
+                                        os.makedirs(version_dir, exist_ok=True)
+                                        face_version_dirs[face_dir_key] = version_dir
+                                    os.replace(existing_face, os.path.join(version_dir, face_filename))
                                 self._save_rgba_image(
                                     record["face_crop"],
                                     None,
@@ -3883,7 +4006,12 @@ class VNCCS_EmotionsGenerator(VNCCS_CharacterGenerator):
                         preview = self._emotion_preview_tensor(final_result)
                         if preview is not None:
                             final_previews.append(preview)
-                            results.append(preview)
+                        if collect_sprites or collect_faces:
+                            retained_output = final_result.detach().cpu()
+                            if collect_sprites:
+                                results.append(retained_output)
+                            if collect_faces:
+                                faces.append(retained_output)
 
                     completed_tasks += len(records)
                     final_preview_batch = self._safe_image_batch(
@@ -3926,6 +4054,7 @@ class VNCCS_EmotionsGenerator(VNCCS_CharacterGenerator):
                     detailer_input = None
                     final_result = None
                     preview = None
+                    retained_output = None
                     record = None
                     self._release_emotion_batch()
 
@@ -3949,12 +4078,13 @@ class VNCCS_EmotionsGenerator(VNCCS_CharacterGenerator):
                     cache_dir=cache_dir,
                 )
 
-            if not results:
+            if completed_tasks <= 0:
                 raise RuntimeError("No emotion images to generate. Select at least one costume and one emotion.")
-            # Full-resolution sprites and variable-size face crops are saved as
-            # individual PNG files during each batch. Return independent display
-            # previews so ComfyUI does not retain every 2656x6336 float tensor.
-            return (results, results)
+            # Full-resolution sprites are always saved during each task. Only
+            # retain IMAGE tensors when a downstream node actually consumes the
+            # corresponding output; the stock Step 3 workflow leaves both ports
+            # disconnected and therefore stays bounded by the task window.
+            return (results, faces)
         except Exception as exc:
             print("[VNCCS Emotions Generator] Failed:", exc)
             traceback.print_exc()
@@ -3994,7 +4124,11 @@ if server is not None:
                 }, status=409)
 
             cache_dir = ctx.get("cache_dir")
-            cached_inputs = _load_run_inputs(cache_dir)
+            generator_type = ctx.get("generator_type") or data.get("generator_type")
+            cached_inputs = _load_run_inputs(
+                cache_dir,
+                keys={"emotion_data"} if generator_type == "VNCCS_EmotionsGenerator" else None,
+            )
             if not cached_inputs:
                 return web.json_response({
                     "error": "Stage input cache is empty. Run this generator once normally before using Regenerate.",
@@ -4005,7 +4139,6 @@ if server is not None:
             if "image_index" in data:
                 widget_payload["regenerate_index"] = data.get("image_index")
             widget_data = json.dumps(widget_payload, ensure_ascii=False)
-            generator_type = ctx.get("generator_type") or data.get("generator_type")
             pipe = ctx["pipe"]
 
             generator_cls = {

--- a/nodes/character_generator.py
+++ b/nodes/character_generator.py
@@ -558,18 +558,6 @@ def _load_cached_tensor(cache_dir, key):
         return None
 
 
-def _remove_cached_tensor(cache_dir, key):
-    path = _cache_tensor_path(cache_dir, key)
-    if not path or not os.path.isfile(path):
-        return False
-    try:
-        os.remove(path)
-        return True
-    except Exception as exc:
-        print(f"[VNCCS Character Generator] Failed to remove cached tensor '{key}': {exc}")
-        return False
-
-
 def _save_run_inputs(cache_dir, **items):
     cache_dir = _safe_cache_dir(cache_dir)
     if not cache_dir:
@@ -2742,30 +2730,6 @@ class VNCCS_EmotionsGenerator(VNCCS_CharacterGenerator):
 
         return connected, known
 
-    def _cleanup_emotion_tensor_cache(self, cache_dir, remove_per_item=False):
-        """Remove legacy combined caches and obsolete per-item caches."""
-        removed = int(_remove_cached_tensor(cache_dir, "input_images"))
-        cache_dir = _safe_cache_dir(cache_dir)
-        stage_dir = os.path.join(cache_dir, "_stage_cache") if cache_dir else ""
-        if not stage_dir or not os.path.isdir(stage_dir):
-            return removed
-        try:
-            for filename in os.listdir(stage_dir):
-                if not filename.startswith("emotion_") or not filename.endswith(".pt"):
-                    continue
-                is_per_item = "__item_" in filename
-                if is_per_item and not remove_per_item:
-                    continue
-                path = os.path.join(stage_dir, filename)
-                if os.path.isfile(path):
-                    os.remove(path)
-                    removed += 1
-        except Exception as exc:
-            print(f"[VNCCS Emotions Generator] Failed to clean obsolete tensor cache: {exc}")
-        if removed:
-            print(f"[VNCCS Emotions Generator] Removed {removed} obsolete cached tensor file(s).")
-        return removed
-
     def _mask_from_source_path(self, path, character_name=""):
         path = _safe_existing_character_image_path(path, character_name)
         if not path or not os.path.exists(path):
@@ -3696,7 +3660,6 @@ class VNCCS_EmotionsGenerator(VNCCS_CharacterGenerator):
                 "[VNCCS Emotions Generator] Pose/emotion input list changed; "
                 "ignoring prior stage cache for this run."
             )
-        self._cleanup_emotion_tensor_cache(cache_dir, remove_per_item=not regenerate_from)
         background_color = self._emotion_background_color(widget_payload, data_items)
         emotion_items = [str(item.get("emotion_prompt", "")) for item in data_items]
         sprite_paths = [str(item.get("sprite_output_path", "")) for item in data_items]

--- a/nodes/emotion_generator_v2.py
+++ b/nodes/emotion_generator_v2.py
@@ -480,6 +480,22 @@ class EmotionGeneratorV2:
         pipe, pipe_seed = build_emotion_pipe(generation_model, generation_settings)
         mode = str(generation_model or "Anima").lower()
         effective_prompt_style = "Anima" if mode == "anima" else "SDXL Style"
+
+        try:
+            generation_settings_data = json.loads(generation_settings) if generation_settings else {}
+        except (TypeError, json.JSONDecodeError):
+            generation_settings_data = {}
+        raw_pose_indices = generation_settings_data.get("selected_pose_indices")
+        selected_pose_indices = None
+        if isinstance(raw_pose_indices, list):
+            selected_pose_indices = set()
+            for value in raw_pose_indices:
+                try:
+                    index = int(value)
+                except (TypeError, ValueError):
+                    continue
+                if index > 0:
+                    selected_pose_indices.add(index)
         
         try:
             selected_costumes = json.loads(costumes_data)
@@ -587,6 +603,8 @@ class EmotionGeneratorV2:
                     emotion_text = f"({emotion_key}, {emotion_description}), {face_details}"
                 
                 for sprite_index, (img_tensor, mask_tensor, _source_path) in enumerate(sprite_items, start=1):
+                    if selected_pose_indices is not None and sprite_index not in selected_pose_indices:
+                        continue
                     images.append(img_tensor)
                     emotion_data.append(json.dumps({
                         "emotion_prompt": emotion_text,

--- a/nodes/emotion_generator_v2.py
+++ b/nodes/emotion_generator_v2.py
@@ -209,18 +209,22 @@ def build_anima_emotion_prompt(natural_prompt, emotion_description, fallback_emo
 
 
 def _load_sprite_tensor(path):
-    img = Image.open(path)
-    img = ImageOps.exif_transpose(img)
-    has_alpha = img.mode == "RGBA" or img.mode == "LA" or (img.mode == "P" and "transparency" in img.info)
-    img = img.convert("RGBA")
-    arr = np.array(img).astype(np.float32) / 255.0
-    image = torch.from_numpy(arr[..., :3]).unsqueeze(0)
-    mask = torch.from_numpy(1.0 - arr[..., 3]).unsqueeze(0) if has_alpha else None
+    with Image.open(path) as opened:
+        img = ImageOps.exif_transpose(opened)
+        has_alpha = img.mode == "RGBA" or img.mode == "LA" or (img.mode == "P" and "transparency" in img.info)
+        rgb_arr = np.asarray(img.convert("RGB"), dtype=np.uint8).copy()
+        alpha_arr = np.asarray(img.convert("RGBA").getchannel("A"), dtype=np.uint8).copy() if has_alpha else None
+    image = torch.from_numpy(rgb_arr).to(dtype=torch.float32).div_(255.0).unsqueeze(0)
+    mask = (
+        1.0 - torch.from_numpy(alpha_arr).to(dtype=torch.float32).div_(255.0).unsqueeze(0)
+        if alpha_arr is not None
+        else None
+    )
     return image, mask
 
 
-def load_costume_sprite_images(character, costume):
-    """Return all current neutral/source sprites for a costume."""
+def list_costume_sprite_paths(character, costume):
+    """Return sorted current neutral/source sprite paths without decoding them."""
     root = os.path.join(character_dir(character), "Sprites", costume)
     paths = []
     if os.path.isdir(root):
@@ -253,9 +257,18 @@ def load_costume_sprite_images(character, costume):
                 continue
             seen_paths.add(path_key)
             paths.append(path)
+    return paths
+
+
+def load_costume_sprite_images(character, costume, selected_pose_indices=None):
+    """Decode only the requested current neutral/source sprites for a costume."""
+    paths = list_costume_sprite_paths(character, costume)
+    selected = set(selected_pose_indices) if selected_pose_indices is not None else None
 
     loaded = []
-    for path in paths:
+    for pose_index, path in enumerate(paths, start=1):
+        if selected is not None and pose_index not in selected:
+            continue
         try:
             image, mask = _load_sprite_tensor(path)
             loaded.append((image, mask, path))
@@ -553,9 +566,17 @@ class EmotionGeneratorV2:
             # Note: selected_costumes comes from frontend which lists them via API
             costume_details, costume_face, costume_head = costume_face_details(character, costume)
             
-            sprite_items = load_costume_sprite_images(character, costume)
-            if not sprite_items:
+            sprite_paths = list_costume_sprite_paths(character, costume)
+            if not sprite_paths:
                 print(f"Failed to load sprites for costume {costume}")
+                continue
+            selected_sprite_paths = [
+                (sprite_index, source_path)
+                for sprite_index, source_path in enumerate(sprite_paths, start=1)
+                if selected_pose_indices is None or sprite_index in selected_pose_indices
+            ]
+            if not selected_sprite_paths:
+                print(f"No selected source poses remain for costume {costume}")
                 continue
 
             for emotion_key in selected_emotions:
@@ -602,10 +623,7 @@ class EmotionGeneratorV2:
                     # SDXL Style (Original logic)
                     emotion_text = f"({emotion_key}, {emotion_description}), {face_details}"
                 
-                for sprite_index, (img_tensor, mask_tensor, _source_path) in enumerate(sprite_items, start=1):
-                    if selected_pose_indices is not None and sprite_index not in selected_pose_indices:
-                        continue
-                    images.append(img_tensor)
+                for sprite_index, _source_path in selected_sprite_paths:
                     emotion_data.append(json.dumps({
                         "emotion_prompt": emotion_text,
                         "positive_prompt": positive_prompt,
@@ -623,13 +641,10 @@ class EmotionGeneratorV2:
                         "sprite_index": sprite_index,
                     }, ensure_ascii=False))
 
-        # Return results even if no images (user may not have connected image input)
-        # But still return valid emotion data
-        if not images:
-            # Return empty lists for images/masks but keep emotion/prompt data valid
-            return [], pipe, emotion_data
-
-        return images, pipe, emotion_data
+        # Source sprites are loaded lazily by VNCCS_EmotionsGenerator. Returning
+        # full-resolution tensors here used to decode every pose before the pose
+        # selection was applied and duplicated them once per selected emotion.
+        return [], pipe, emotion_data
 
 NODE_CLASS_MAPPINGS = {
     "EmotionGeneratorV2": EmotionGeneratorV2

--- a/web/vnccs_character_generator.js
+++ b/web/vnccs_character_generator.js
@@ -42,6 +42,7 @@ const DEFAULT_DATA = {
         temporal_overlap: 8,
     },
     emotion_generation: {
+        task_batch_size: 0,
         face_denoise: 0.55,
         use_sam: true,
         bbox_model: "bbox/face_yolov8m.pt",
@@ -1075,7 +1076,8 @@ class CharacterGeneratorWidget {
             } else {
                 const status = detail.status || "waiting";
                 if (status === "running") {
-                    this.resetStagesFrom(stage);
+                    const continuingBatch = Boolean(detail.append_images) && this.stageState[stage]?.status === "running";
+                    if (!continuingBatch) this.resetStagesFrom(stage);
                     if (stage === "pose_generation" || stage === "original_pose_generation" || stage === "source_upscaler") {
                         this.userSelectedPreview = false;
                         if (!this.data.ui) this.data.ui = {};
@@ -1084,9 +1086,12 @@ class CharacterGeneratorWidget {
                 }
                 const previousStageState = this.stageState[stage] || {};
                 const hasImages = Object.prototype.hasOwnProperty.call(detail, "images");
+                const nextImages = hasImages && detail.append_images
+                    ? [...(previousStageState.images || []), ...(detail.images || [])]
+                    : (hasImages ? detail.images : (previousStageState.images || null));
                 this.stageState[stage] = {
                     status,
-                    images: hasImages ? detail.images : (previousStageState.images || null),
+                    images: nextImages,
                     message: detail.message || "",
                     current: detail.current,
                     total: detail.total,
@@ -2455,6 +2460,7 @@ class CharacterGeneratorWidget {
                 this.faceDenoiseSlider(),
             ]));
             const faceDetailerFields = [
+                this.faceDetailerNumberField("task_batch_size", "task_batch_size (0 = auto)", { min: 0, max: 32, step: 1 }),
                 this.field("emotion_generation", "use_sam", "Use SAM", "checkbox"),
                 this.faceDetailerNumberField("bbox_threshold", "bbox_threshold", { min: 0, max: 1, step: 0.01 }),
                 this.faceDetailerNumberField("bbox_dilation", "bbox_dilation", { min: 0, max: 128, step: 1 }),

--- a/web/vnccs_character_generator.js
+++ b/web/vnccs_character_generator.js
@@ -1075,8 +1075,11 @@ class CharacterGeneratorWidget {
                 this.finishRegenerate();
             } else {
                 const status = detail.status || "waiting";
+                const previousStageState = this.stageState[stage] || {};
+                const hasImages = Object.prototype.hasOwnProperty.call(detail, "images");
                 if (status === "running") {
-                    const continuingBatch = Boolean(detail.append_images) && this.stageState[stage]?.status === "running";
+                    const continuingBatch = previousStageState.status === "running"
+                        && (Boolean(detail.append_images) || !hasImages);
                     if (!continuingBatch) this.resetStagesFrom(stage);
                     if (stage === "pose_generation" || stage === "original_pose_generation" || stage === "source_upscaler") {
                         this.userSelectedPreview = false;
@@ -1084,8 +1087,6 @@ class CharacterGeneratorWidget {
                         this.data.ui.user_selected_preview = false;
                     }
                 }
-                const previousStageState = this.stageState[stage] || {};
-                const hasImages = Object.prototype.hasOwnProperty.call(detail, "images");
                 const nextImages = hasImages && detail.append_images
                     ? [...(previousStageState.images || []), ...(detail.images || [])]
                     : (hasImages ? detail.images : (previousStageState.images || null));

--- a/web/vnccs_emotion_v2.js
+++ b/web/vnccs_emotion_v2.js
@@ -2713,7 +2713,7 @@ app.registerExtension({
                         showModalText("No emotions selected", "Please select at least one emotion.");
                         return false;
                     }
-                    if (state.poseCount > 0 && selectedPoseCount() === 0) {
+                    if (state.selectedPoseIndices !== null && selectedPoseIndexList().length === 0) {
                         showModalText("No poses selected", "Select at least one pose in Generate poses.");
                         return false;
                     }
@@ -2845,7 +2845,7 @@ app.registerExtension({
                         // Select All Visible
                         const numEmotions = filtered.length;
                         const numCostumes = state.selectedCostumes.size;
-                        const numPoses = selectedPoseCount() || state.poseCount || 0;
+                        const numPoses = selectedPoseCount();
                         const total = numEmotions * numCostumes * numPoses;
 
                         showConfirm("Select visible emotions", `Emotions: ${numEmotions}\nCostumes: ${numCostumes}\nPoses: ${numPoses}\nTotal: ${total} images.`, () => {

--- a/web/vnccs_emotion_v2.js
+++ b/web/vnccs_emotion_v2.js
@@ -201,6 +201,74 @@ const STYLE = `
     font-size: 10px;
     color: var(--text-secondary);
 }
+.ems-pose-selection {
+    margin-top: 7px;
+    padding: 7px;
+    border: 1px solid var(--border);
+    border-radius: var(--radius-md);
+    background: rgba(10, 8, 16, 0.55);
+}
+.ems-pose-selection-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 8px;
+    margin-bottom: 6px;
+}
+.ems-pose-selection-title {
+    color: var(--accent);
+    font-size: 9px;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 1px;
+}
+.ems-pose-selection-summary {
+    color: var(--text-secondary);
+    font-family: var(--font-mono);
+    font-size: 9px;
+}
+.ems-pose-grid {
+    display: grid;
+    grid-template-columns: repeat(6, minmax(0, 1fr));
+    gap: 4px;
+}
+.ems-pose-chip {
+    min-width: 0;
+    height: 24px;
+    padding: 0;
+    border: 1px solid var(--border-hover);
+    border-radius: 6px;
+    background: rgba(255, 255, 255, 0.035);
+    color: var(--text-muted);
+    font-family: var(--font-mono);
+    font-size: 9px;
+    cursor: pointer;
+}
+.ems-pose-chip.selected {
+    border-color: var(--accent-border);
+    background: rgba(255, 143, 163, 0.16);
+    color: var(--accent-hover);
+}
+.ems-pose-chip.current {
+    outline: 1px solid var(--accent-lavender);
+    outline-offset: 1px;
+}
+.ems-pose-selection-actions {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 5px;
+    margin-top: 6px;
+}
+.ems-pose-selection-action {
+    height: 24px;
+    border: 1px solid var(--accent-border);
+    border-radius: 6px;
+    background: rgba(255, 143, 163, 0.08);
+    color: var(--text-secondary);
+    font-size: 9px;
+    font-weight: 700;
+    cursor: pointer;
+}
 @keyframes ems-spin { to { transform: rotate(360deg); } }
 
 /* ── Costumes ── */
@@ -1159,11 +1227,22 @@ app.registerExtension({
                     selectedEmotions: new Set(),
                     searchTerm: "",
                     selectedPreviewSprite: null,
+                    selectedPoseIndices: null,
+                    poseCount: 0,
                     gen: parseGenerationSettings()
                 };
+                if (Array.isArray(state.gen.selected_pose_indices)) {
+                    state.selectedPoseIndices = new Set(
+                        state.gen.selected_pose_indices
+                            .map(value => Number.parseInt(value, 10))
+                            .filter(value => Number.isInteger(value) && value > 0)
+                    );
+                }
                 let receivedSerializedConfig = false;
                 let characterFetchToken = 0;
                 let spritePreviewNavigator = null;
+                let poseSelectionSummary = null;
+                let poseSelectionGrid = null;
                 const CC_REPO_ID = "MIUProject/VNCCS_v3.0";
                 const CC_CACHE_KEY = `vnccs_cc_cache_${CC_REPO_ID}`;
                 let ccConfig = null;
@@ -1259,6 +1338,74 @@ app.registerExtension({
                     markNodeDirty();
                 }
 
+                function selectedPoseIndexList() {
+                    if (state.selectedPoseIndices === null) return null;
+                    return Array.from(state.selectedPoseIndices)
+                        .filter(index => Number.isInteger(index) && index > 0 && (!state.poseCount || index <= state.poseCount))
+                        .sort((a, b) => a - b);
+                }
+
+                function syncSelectedPoseIndicesToGenerationSettings() {
+                    const indices = selectedPoseIndexList();
+                    if (indices === null) delete state.gen.selected_pose_indices;
+                    else state.gen.selected_pose_indices = indices;
+                }
+
+                function restorePoseSelectionFromGenerationSettings() {
+                    const stored = state.gen?.selected_pose_indices;
+                    state.selectedPoseIndices = Array.isArray(stored)
+                        ? new Set(
+                            stored
+                                .map(value => Number.parseInt(value, 10))
+                                .filter(value => Number.isInteger(value) && value > 0)
+                        )
+                        : null;
+                }
+
+                function isPoseSelected(index) {
+                    return state.selectedPoseIndices === null || state.selectedPoseIndices.has(index);
+                }
+
+                function selectedPoseCount() {
+                    if (state.poseCount <= 0) return 0;
+                    return state.selectedPoseIndices === null
+                        ? state.poseCount
+                        : selectedPoseIndexList().length;
+                }
+
+                function renderPoseSelection() {
+                    if (!poseSelectionSummary || !poseSelectionGrid) return;
+                    const count = state.poseCount;
+                    const selectedCount = selectedPoseCount();
+                    poseSelectionSummary.textContent = count > 0
+                        ? `${selectedCount}/${count} selected`
+                        : "No poses";
+                    poseSelectionGrid.innerHTML = "";
+                    const currentIndex = Number(state.selectedPreviewSprite?.index ?? -1) + 1;
+                    for (let index = 1; index <= count; index++) {
+                        const chip = document.createElement("button");
+                        chip.type = "button";
+                        chip.className = "ems-pose-chip";
+                        chip.classList.toggle("selected", isPoseSelected(index));
+                        chip.classList.toggle("current", currentIndex === index);
+                        chip.textContent = String(index);
+                        chip.title = `Pose ${index}: click to ${isPoseSelected(index) ? "exclude" : "include"}`;
+                        chip.onclick = () => {
+                            if (state.selectedPoseIndices === null) {
+                                state.selectedPoseIndices = new Set(
+                                    Array.from({ length: state.poseCount }, (_, itemIndex) => itemIndex + 1)
+                                );
+                            }
+                            if (state.selectedPoseIndices.has(index)) state.selectedPoseIndices.delete(index);
+                            else state.selectedPoseIndices.add(index);
+                            spritePreviewNavigator?.show(index - 1);
+                            saveGenerationSettings();
+                            renderPoseSelection();
+                        };
+                        poseSelectionGrid.appendChild(chip);
+                    }
+                }
+
                 function persistAllState() {
                     commitWidget(charWidget, state.character, false);
                     if (styleWidget) commitWidget(styleWidget, promptStyleForMode(state.gen.generation_mode), false);
@@ -1269,6 +1416,7 @@ app.registerExtension({
 
                 function saveGenerationSettings() {
                     const callCallback = arguments.length > 0 ? arguments[0] : true;
+                    syncSelectedPoseIndicesToGenerationSettings();
                     const mode = (state.gen.generation_mode || "anima").toLowerCase();
                     const sharedSeed = state.gen.seed ?? initialSharedSeed;
                     const sharedSeedMode = state.gen.seed_mode || "fixed";
@@ -1971,6 +2119,44 @@ app.registerExtension({
                 spriteNextBtn.innerHTML = '<svg viewBox="0 0 24 24" aria-hidden="true"><path d="M9 6l6 6-6 6"/></svg>';
                 spriteNav.append(spritePrevBtn, spriteCount, spriteNextBtn);
                 charSection.appendChild(spriteNav);
+
+                const poseSelection = document.createElement("div");
+                poseSelection.className = "ems-pose-selection";
+                const poseSelectionHeader = document.createElement("div");
+                poseSelectionHeader.className = "ems-pose-selection-header";
+                const poseSelectionTitle = document.createElement("div");
+                poseSelectionTitle.className = "ems-pose-selection-title";
+                poseSelectionTitle.textContent = "Generate poses";
+                poseSelectionSummary = document.createElement("div");
+                poseSelectionSummary.className = "ems-pose-selection-summary";
+                poseSelectionSummary.textContent = "Loading...";
+                poseSelectionHeader.append(poseSelectionTitle, poseSelectionSummary);
+                poseSelectionGrid = document.createElement("div");
+                poseSelectionGrid.className = "ems-pose-grid";
+                const poseSelectionActions = document.createElement("div");
+                poseSelectionActions.className = "ems-pose-selection-actions";
+                const selectAllPoses = document.createElement("button");
+                selectAllPoses.type = "button";
+                selectAllPoses.className = "ems-pose-selection-action";
+                selectAllPoses.textContent = "SELECT ALL";
+                selectAllPoses.onclick = () => {
+                    state.selectedPoseIndices = null;
+                    saveGenerationSettings();
+                    renderPoseSelection();
+                };
+                const clearAllPoses = document.createElement("button");
+                clearAllPoses.type = "button";
+                clearAllPoses.className = "ems-pose-selection-action";
+                clearAllPoses.textContent = "CLEAR ALL";
+                clearAllPoses.onclick = () => {
+                    state.selectedPoseIndices = new Set();
+                    saveGenerationSettings();
+                    renderPoseSelection();
+                };
+                poseSelectionActions.append(selectAllPoses, clearAllPoses);
+                poseSelection.append(poseSelectionHeader, poseSelectionGrid, poseSelectionActions);
+                charSection.appendChild(poseSelection);
+
                 spritePreviewNavigator = createSpritePreviewNavigator({
                     image: charImg,
                     placeholder: charPlaceholder,
@@ -1980,6 +2166,12 @@ app.registerExtension({
                     nextButton: spriteNextBtn,
                     countLabel: spriteCount,
                     onLoaded: (_url, previewState) => {
+                        state.poseCount = Math.max(0, Number(previewState.count || 0));
+                        if (state.selectedPoseIndices !== null) {
+                            state.selectedPoseIndices = new Set(
+                                selectedPoseIndexList().filter(index => index <= state.poseCount)
+                            );
+                        }
                         state.selectedPreviewSprite = previewState.count > 0
                             ? {
                                 character: previewState.character,
@@ -1990,11 +2182,14 @@ app.registerExtension({
                             : null;
                         state.gen.selected_preview_sprite = state.selectedPreviewSprite;
                         saveGenerationSettings(false);
+                        renderPoseSelection();
                     },
                     onMissing: () => {
+                        state.poseCount = 0;
                         state.selectedPreviewSprite = null;
                         delete state.gen.selected_preview_sprite;
                         saveGenerationSettings(false);
+                        renderPoseSelection();
                     },
                 });
                 leftCol.appendChild(charSection);
@@ -2518,6 +2713,10 @@ app.registerExtension({
                         showModalText("No emotions selected", "Please select at least one emotion.");
                         return false;
                     }
+                    if (state.poseCount > 0 && selectedPoseCount() === 0) {
+                        showModalText("No poses selected", "Select at least one pose in Generate poses.");
+                        return false;
+                    }
                     return true;
                 };
 
@@ -2542,9 +2741,11 @@ app.registerExtension({
                     }
                     if (generationSettingsWidget && generationSettingsWidget.value) {
                         state.gen = parseGenerationSettings();
+                        restorePoseSelectionFromGenerationSettings();
                     }
                     if (styleWidget) commitWidget(styleWidget, promptStyleForMode(state.gen.generation_mode), false);
                     syncGenerationControls();
+                    renderPoseSelection();
 
                     // 3. Costumes & Emotions (from hidden text strings)
                     if (costumesDataWidget && costumesDataWidget.value) {
@@ -2644,9 +2845,10 @@ app.registerExtension({
                         // Select All Visible
                         const numEmotions = filtered.length;
                         const numCostumes = state.selectedCostumes.size;
-                        const total = numEmotions * numCostumes;
+                        const numPoses = selectedPoseCount() || state.poseCount || 0;
+                        const total = numEmotions * numCostumes * numPoses;
 
-                        showConfirm("Select visible emotions", `Emotions: ${numEmotions}\nCostumes: ${numCostumes}\nTotal: ${total} images.`, () => {
+                        showConfirm("Select visible emotions", `Emotions: ${numEmotions}\nCostumes: ${numCostumes}\nPoses: ${numPoses}\nTotal: ${total} images.`, () => {
                             filtered.forEach(e => state.selectedEmotions.add(e.safe_name));
                             renderEmotions();
                             updateEmotionsData();
@@ -2668,8 +2870,13 @@ app.registerExtension({
 
                 function resetSelectedEmotionsForCharacterChange() {
                     state.selectedEmotions = new Set();
+                    state.selectedPoseIndices = null;
+                    state.poseCount = 0;
+                    delete state.gen.selected_pose_indices;
                     updateEmotionsData();
                     renderEmotions();
+                    saveGenerationSettings(false);
+                    renderPoseSelection();
                 }
 
                 function createEmotionCard(e, compact = false) {


### PR DESCRIPTION
## Summary

- Add pose selection to Step 3, so only the selected pose and emotion combinations are generated.
- Load pose images only when their batch starts instead of loading every pose up front.
- Split generation into small batches based on available GPU memory, system memory, and image size.
- Store intermediate tensors per image as float16 instead of building one large input tensor.
- Return generated images as separate list items when an output is connected. Unused outputs no longer keep all full-resolution images in memory.
- During a partial run, back up only the face files that will be replaced. Files for unselected poses stay in place.
- Keep generated previews visible while later batches report progress.

## Changed files

- `nodes/emotion_generator_v2.py`: Read the selected pose indices and create jobs only for those poses. Pose files are passed by path and decoded later.
- `nodes/character_generator.py`: Load source images per batch, choose a safe batch size, release batch tensors after use, handle output lists, and preserve face files from unselected poses.
- `web/vnccs_emotion_v2.js`: Add pose selection controls, save the selection, reject an empty selection, and show the correct job count.
- `web/vnccs_character_generator.js`: Keep earlier preview images when a progress update has no new images.

## Root cause

Step 3 loaded all pose images before filtering them, duplicated the tensors for each emotion, and cached them together as `input_images`. A `6336 × 2656` RGBA float32 image uses about 257 MiB, so a normal pose and emotion set could exhaust RAM and VRAM before batching started. On Windows, the failed run ended with an access violation in `c10.dll`.

## Validation

- Tested locally on an NVIDIA RTX 4080 with several pose and emotion selections. Generation ran without OOM or crashes, and memory usage stayed stable between batches.

## Notes

- Connecting the `sprites` or `faces` output keeps those full-resolution images in memory until the next node finishes.
- Pose selection assumes the preview and costume sprite folders use the same pose order.
